### PR TITLE
[2.0.0.pre.2] A new way to define flows with collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,10 @@ end
 # Creating a flow using the collection syntax #
 #---------------------------------------------#
 
-Add2ToAllNumbers = Micro::Case::Flow[
+Add2ToAllNumbers = Micro::Case::Flow([
   Steps::ConvertToNumbers,
   Steps::Add2
-]
+])
 
 result = Add2ToAllNumbers.call(numbers: %w[1 1 2 2 3 4])
 
@@ -594,12 +594,12 @@ end
 # or
 
 module Users
-  Create = Micro::Case::Safe::Flow[
+  Create = Micro::Case::Safe::Flow([
     ProcessParams,
     ValidateParams,
     Persist,
     SendToCRM
-  ]
+  ])
 end
 ```
 

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -20,12 +20,16 @@ module Micro
       Proc.new { |arg| call(arg) }
     end
 
+    def self.Flow(args)
+      Flow::Reducer.build(Array(args))
+    end
+
     def self.>>(use_case)
-      Flow[self, use_case]
+      Flow([self, use_case])
     end
 
     def self.&(use_case)
-      Safe::Flow[self, use_case]
+      Safe::Flow([self, use_case])
     end
 
     def self.call(options = {})

--- a/lib/micro/case/flow.rb
+++ b/lib/micro/case/flow.rb
@@ -37,10 +37,6 @@ module Micro
         base.class_eval(CONSTRUCTOR)
       end
 
-      def self.[](*args)
-        Reducer.build(args)
-      end
-
       def call
         self.class.__flow__.call(@options)
       end

--- a/lib/micro/case/safe.rb
+++ b/lib/micro/case/safe.rb
@@ -3,6 +3,10 @@
 module Micro
   class Case
     class Safe < ::Micro::Case
+      def self.Flow(args)
+        Flow::Reducer.build(Array(args))
+      end
+
       def call
         super
       rescue => exception

--- a/lib/micro/case/safe/flow.rb
+++ b/lib/micro/case/safe/flow.rb
@@ -10,8 +10,8 @@ module Micro
           def base.flow_reducer; Reducer; end
         end
 
-        def self.[](*args)
-          Reducer.build(args)
+        def self.Flow(args)
+          Reducer.build(Array(args))
         end
 
         class Reducer < ::Micro::Case::Flow::Reducer

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '2.0.0.pre'.freeze
+    VERSION = '2.0.0.pre.2'.freeze
   end
 end

--- a/test/micro/case/calling_test.rb
+++ b/test/micro/case/calling_test.rb
@@ -5,10 +5,10 @@ require 'support/steps'
 class Micro::Case::CallingTest < Minitest::Test
   Failure = Micro::Case::Result
 
-  Add2ToAllNumbers1 = Micro::Case::Flow[
+  Add2ToAllNumbers1 = Micro::Case::Flow([
     Steps::ConvertToNumbers,
     Steps::Add2
-  ]
+  ])
 
   class Add2ToAllNumbers2
     include Micro::Case::Flow

--- a/test/micro/case/flow/blend_test.rb
+++ b/test/micro/case/flow/blend_test.rb
@@ -5,10 +5,10 @@ require 'support/steps'
 class Micro::Case::Flow::BlendTest < Minitest::Test
   Add2ToAllNumbers = Steps::ConvertToNumbers >> Steps::Add2
 
-  DoubleAllNumbers = Micro::Case::Flow[
+  DoubleAllNumbers = Micro::Case::Flow([
     Steps::ConvertToNumbers,
     Steps::Double
-  ]
+  ])
 
   class SquareAllNumbers
     include Micro::Case::Flow
@@ -18,9 +18,9 @@ class Micro::Case::Flow::BlendTest < Minitest::Test
 
   DoubleAllNumbersAndAdd2 = DoubleAllNumbers >> Steps::Add2
 
-  SquareAllNumbersAndAdd2 = Micro::Case::Flow[
+  SquareAllNumbersAndAdd2 = Micro::Case::Flow([
     SquareAllNumbers, Steps::Add2
-  ]
+  ])
 
   SquareAllNumbersAndDouble = SquareAllNumbersAndAdd2 >> DoubleAllNumbers
 

--- a/test/micro/case/flow/collection_mapper_test.rb
+++ b/test/micro/case/flow/collection_mapper_test.rb
@@ -3,37 +3,36 @@ require 'test_helper'
 require 'support/steps'
 
 class Micro::Case::Flow::CollectionMapperTest < Minitest::Test
-  Add2ToAllNumbers = Micro::Case::Flow[
+  Add2ToAllNumbers = Micro::Case::Flow([
     Steps::ConvertToNumbers,
     Steps::Add2
-  ]
+  ])
 
-  DoubleAllNumbers = Micro::Case::Flow[
+  DoubleAllNumbers = Micro::Case::Flow([
     Steps::ConvertToNumbers,
     Steps::Double
-  ]
+  ])
 
-  SquareAllNumbers = Micro::Case::Flow[
+  SquareAllNumbers = Micro::Case::Flow([
     Steps::ConvertToNumbers,
     Steps::Square
-  ]
+  ])
 
-  DoubleAllNumbersAndAdd2 = Micro::Case::Flow[
+  DoubleAllNumbersAndAdd2 = Micro::Case::Flow([
     DoubleAllNumbers,
     Steps::Add2
-  ]
+  ])
 
-  SquareAllNumbersAndAdd2 = Micro::Case::Flow[
+  SquareAllNumbersAndAdd2 = Micro::Case::Flow([
     SquareAllNumbers,
     Steps::Add2
-  ]
+  ])
 
   SquareAllNumbersAndDouble =
-    Micro::Case::Flow[SquareAllNumbersAndAdd2, DoubleAllNumbers]
+    Micro::Case::Flow([SquareAllNumbersAndAdd2, DoubleAllNumbers])
 
-    DoubleAllNumbersAndSquareAndAdd2 =
-    Micro::Case::Flow[DoubleAllNumbers, SquareAllNumbersAndAdd2]
-
+  DoubleAllNumbersAndSquareAndAdd2 =
+    Micro::Case::Flow([DoubleAllNumbers, SquareAllNumbersAndAdd2])
 
   EXAMPLES = [
     { flow: Add2ToAllNumbers, result: [3, 3, 4, 4, 5, 6] },

--- a/test/micro/case/safe/flow/blend_test.rb
+++ b/test/micro/case/safe/flow/blend_test.rb
@@ -5,10 +5,10 @@ require 'support/steps'
 class Micro::Case::Safe::Flow::BlendTest < Minitest::Test
   Add2ToAllNumbers = Steps::ConvertToNumbers & Steps::Add2
 
-  DoubleAllNumbers = Micro::Case::Safe::Flow[
+  DoubleAllNumbers = Micro::Case::Safe::Flow([
     Steps::ConvertToNumbers,
     Steps::Double
-  ]
+  ])
 
   class SquareAllNumbers
     include Micro::Case::Safe::Flow
@@ -18,9 +18,9 @@ class Micro::Case::Safe::Flow::BlendTest < Minitest::Test
 
   DoubleAllNumbersAndAdd2 = DoubleAllNumbers & Steps::Add2
 
-  SquareAllNumbersAndAdd2 = Micro::Case::Safe::Flow[
+  SquareAllNumbersAndAdd2 = Micro::Case::Safe::Flow([
     SquareAllNumbers, Steps::Add2
-  ]
+  ])
 
   SquareAllNumbersAndDouble = SquareAllNumbersAndAdd2 & DoubleAllNumbers
 
@@ -66,10 +66,10 @@ class Micro::Case::Safe::Flow::BlendTest < Minitest::Test
 
   Add2ToAllNumbersAndDivideByZero = Add2ToAllNumbers & DivideNumbersByZero
 
-  DoubleAllNumbersAndDivideByZero = Micro::Case::Safe::Flow[
+  DoubleAllNumbersAndDivideByZero = Micro::Case::Safe::Flow([
     DoubleAllNumbers,
     DivideNumbersByZero
-  ]
+  ])
 
   class SquareAllNumbersAndDivideByZero
     include Micro::Case::Safe::Flow

--- a/test/micro/case/safe/flow/collection_mapper_test.rb
+++ b/test/micro/case/safe/flow/collection_mapper_test.rb
@@ -3,36 +3,36 @@ require 'test_helper'
 require 'support/steps'
 
 class Micro::Case::Safe::Flow::CollectionMapperTest < Minitest::Test
-  Add2ToAllNumbers = Micro::Case::Safe::Flow[
+  Add2ToAllNumbers = Micro::Case::Safe::Flow([
     Steps::ConvertToNumbers,
     Steps::Add2
-  ]
+  ])
 
-  DoubleAllNumbers = Micro::Case::Safe::Flow[
+  DoubleAllNumbers = Micro::Case::Safe::Flow([
     Steps::ConvertToNumbers,
     Steps::Double
-  ]
+  ])
 
-  SquareAllNumbers = Micro::Case::Safe::Flow[
+  SquareAllNumbers = Micro::Case::Safe::Flow([
     Steps::ConvertToNumbers,
     Steps::Square
-  ]
+  ])
 
-  DoubleAllNumbersAndAdd2 = Micro::Case::Safe::Flow[
+  DoubleAllNumbersAndAdd2 = Micro::Case::Safe::Flow([
     DoubleAllNumbers,
     Steps::Add2
-  ]
+  ])
 
-  SquareAllNumbersAndAdd2 = Micro::Case::Safe::Flow[
+  SquareAllNumbersAndAdd2 = Micro::Case::Safe::Flow([
     SquareAllNumbers,
     Steps::Add2
-  ]
+  ])
 
   SquareAllNumbersAndDouble =
-    Micro::Case::Safe::Flow[SquareAllNumbersAndAdd2, DoubleAllNumbers]
+    Micro::Case::Safe::Flow([SquareAllNumbersAndAdd2, DoubleAllNumbers])
 
   DoubleAllNumbersAndSquareAndAdd2 =
-    Micro::Case::Safe::Flow[DoubleAllNumbers, SquareAllNumbersAndAdd2]
+    Micro::Case::Safe::Flow([DoubleAllNumbers, SquareAllNumbersAndAdd2])
 
 
   EXAMPLES = [

--- a/test/micro/case/with_validation/base_test.rb
+++ b/test/micro/case/with_validation/base_test.rb
@@ -31,7 +31,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         # ---
 
-        flow = Micro::Case::Flow[Multiply, NumberToString]
+        flow = Micro::Case::Flow([Multiply, NumberToString])
 
         assert_result_success(flow.call(a: 2, b: 2), value: '4')
       end

--- a/test/micro/case/with_validation/safe/base_test.rb
+++ b/test/micro/case/with_validation/safe/base_test.rb
@@ -31,7 +31,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         # ---
 
-        flow = Micro::Case::Flow[Multiply, NumberToString]
+        flow = Micro::Case::Flow([Multiply, NumberToString])
 
         assert_result_success(flow.call(a: 2, b: 2), value: '4')
       end

--- a/test/micro/case/with_validation/safe/strict_test.rb
+++ b/test/micro/case/with_validation/safe/strict_test.rb
@@ -31,7 +31,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         # ---
 
-        flow = Micro::Case::Flow[Multiply, NumberToString]
+        flow = Micro::Case::Flow([Multiply, NumberToString])
 
         assert_result_success(flow.call(a: 2, b: 2), value: '4')
       end

--- a/test/micro/case/with_validation/strict_test.rb
+++ b/test/micro/case/with_validation/strict_test.rb
@@ -31,7 +31,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         # ---
 
-        flow = Micro::Case::Flow[Multiply, NumberToString]
+        flow = Micro::Case::Flow([Multiply, NumberToString])
 
         assert_result_success(flow.call(a: 2, b: 2), value: '4')
       end


### PR DESCRIPTION
This pull request adds a new breaking change because of its changes in the way of how to define flows using collections.

Now, is expected an array as the argument of `Micro::Case::Flow()` and `Micro::Case::Safe::Flow()` methods. 