### PR TITLE
[2.0.0.pre.3] Expose a new result data in the on_failure hook

### DIFF
--- a/lib/micro/case/safe.rb
+++ b/lib/micro/case/safe.rb
@@ -3,10 +3,6 @@
 module Micro
   class Case
     class Safe < ::Micro::Case
-      def self.Flow(args)
-        Flow::Reducer.build(Array(args))
-      end
-
       def call
         super
       rescue => exception

--- a/lib/micro/case/safe/flow.rb
+++ b/lib/micro/case/safe/flow.rb
@@ -10,10 +10,6 @@ module Micro
           def base.flow_reducer; Reducer; end
         end
 
-        def self.Flow(args)
-          Reducer.build(Array(args))
-        end
-
         class Reducer < ::Micro::Case::Flow::Reducer
           def call(arg = {})
             @use_cases.reduce(initial_result(arg)) do |result, use_case|
@@ -42,6 +38,10 @@ module Micro
               end
             end
         end
+      end
+
+      def self.Flow(args)
+        Flow::Reducer.build(Array(args))
       end
     end
   end

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '2.0.0.pre.2'.freeze
+    VERSION = '2.0.0.pre.3'.freeze
   end
 end

--- a/test/micro/case/flow_test.rb
+++ b/test/micro/case/flow_test.rb
@@ -15,7 +15,9 @@ class Micro::Case::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure do |(value, type)|
+        assert_equal(:invalid_state_transition, value)
+      end
   end
 
   def test_calling_with_a_flow
@@ -43,7 +45,7 @@ class Micro::Case::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, _type)| assert_equal(:invalid_state_transition, value) }
   end
 
   def test_calling_with_a_use_case_instance
@@ -61,7 +63,7 @@ class Micro::Case::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |data| assert_equal(:invalid_state_transition, data.value) }
   end
 
   def test_calling_with_a_use_case_class

--- a/test/micro/case/safe/flow/base_test.rb
+++ b/test/micro/case/safe/flow/base_test.rb
@@ -15,7 +15,7 @@ class Micro::Case::Safe::Flow::BaseTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, type)| assert_equal(:invalid_state_transition, value) }
   end
 
   def test_calling_with_a_flow
@@ -29,7 +29,7 @@ class Micro::Case::Safe::Flow::BaseTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |data| assert_equal(:invalid_state_transition, data.value) }
   end
 
   def test_calling_with_a_flow
@@ -43,7 +43,7 @@ class Micro::Case::Safe::Flow::BaseTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, *)| assert_equal(:invalid_state_transition, value) }
   end
 
   def test_calling_with_a_use_case_instance
@@ -61,7 +61,7 @@ class Micro::Case::Safe::Flow::BaseTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |value| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, _type)| assert_equal(:invalid_state_transition, value) }
   end
 
   def test_calling_with_a_use_case_class


### PR DESCRIPTION
# Why the on_failure result hook exposes a different kind of data?

Answer: To allow you to define how to handle the program flow using some
conditional statement (like an `if`, `case/when`).

```ruby
class Double < Micro::Case
  attribute :number

  def call!
    return Failure(:invalid) unless number.is_a?(Numeric)
    return Failure(:lte_zero) if number <= 0

    Success(number * 2)
  end
end

#=================================#
# Using the result type and value #
#=================================#

Double
  .call(-1)
  .on_failure do |result, use_case|
    case result.type
    when :invalid then raise TypeError, 'the number must be a numeric value'
    when :lte_zero then raise ArgumentError, "the number `#{result.value}` must be greater than 0"
    else raise NotImplementedError
    end
  end

# The output will be the exception:
#
# ArgumentError (the number `-1` must be greater than 0)

#=====================================================#
# Using decomposition to access result value and type #
#=====================================================#

# The syntax to decompose an Array can be used in methods, blocks and assigments.
# If you doesn't know that, check out:
# https://ruby-doc.org/core-2.2.0/doc/syntax/assignment_rdoc.html#label-Array+Decomposition
#
# And the object exposed in the hook failure can be decomposed using this syntax. e.g:

Double
  .call(-2)
  .on_failure do |(value, type), use_case|
    case type
    when :invalid then raise TypeError, 'the number must be a numeric value'
    when :lte_zero then raise ArgumentError, "the number `#{value}` must be greater than 0"
    else raise NotImplementedError
    end
  end

# The output will be the exception:
#
# ArgumentError (the number `-2` must be greater than 0)
```