### PR TITLE
Micro::Case::Result#data

### DIFF
--- a/lib/micro/case/flow/reducer.rb
+++ b/lib/micro/case/flow/reducer.rb
@@ -26,13 +26,12 @@ module Micro
         end
 
         def call(arg = {})
-          memo = arg.is_a?(Hash) ? arg.dup : {}
+          input = arg.is_a?(Hash) ? arg.dup : {}
 
           @use_cases.reduce(initial_result(arg)) do |result, use_case|
             break result if result.failure?
 
-            value = result.value
-            input = value.is_a?(Hash) ? memo.tap { |data| data.merge!(value) } : value
+            input.merge!(result.data)
 
             use_case_result(use_case, result, input)
           end
@@ -61,7 +60,7 @@ module Micro
             return arg if arg.is_a?(Micro::Case::Result)
 
             result = ::Micro::Case::Result.new
-            result.__set__(true, arg, :ok, nil)
+            result.__set__(true, Attributes::AttributesUtils.hash_argument!(arg), :ok, nil)
           end
 
           def arg_to_call?(arg)

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -130,4 +130,63 @@ class Micro::Case::ResultTest < Minitest::Test
       result.__set__(true, :value, 'type', nil)
     end
   end
+
+  def test_the_data_method
+    use_case = Micro::Case.new({})
+
+    # ---
+
+    result0 = success_result(value: 0, type: :ok)
+
+    assert_equal({ value: 0 }, result0.data)
+    assert_equal(result0.data, result0.to_h)
+    assert_equal(0, result0[:value])
+
+    # ---
+
+    result1 = failure_result(value: 1, type: :error, use_case: use_case)
+
+    assert_equal({ value: 1 }, result1.data)
+    assert_equal(result1.data, result1.to_h)
+    assert_equal(1, result1[:value])
+
+    assert_predicate(result1, :failure?)
+
+    result1.on_failure do |result|
+      assert_equal({ value: 1 }, result.data)
+      assert_equal(result1.data, result1.to_h)
+      assert_equal(1, result1[:value])
+    end
+
+    # ---
+
+    result2 = failure_result(value: :invalid_data, type: :invalid_data, use_case: use_case)
+
+    assert_equal({ invalid_data: true }, result2.data)
+    assert_equal(result2.data, result2.to_h)
+    assert_equal(true, result2[:invalid_data])
+
+    assert_predicate(result2, :failure?)
+
+    result2.on_failure do |result|
+      assert_equal({ invalid_data: true }, result.data)
+      assert_equal(result2.data, result2.to_h)
+      assert_equal(true, result2[:invalid_data])
+    end
+
+    # ---
+
+    result3 = failure_result(value: { one: 1, two: 2 }, type: :error, use_case: use_case)
+
+    assert_equal({ one: 1, two: 2 }, result3.data)
+
+    assert_predicate(result3, :failure?)
+
+    result3.on_failure do |result|
+      assert_equal({ one: 1, two: 2 }, result.data)
+      assert_equal(result3.data, result3.to_h)
+      assert_equal(1, result3[:one])
+      assert_equal(2, result3[:two])
+    end
+  end
 end


### PR DESCRIPTION
- [x] Implement `Micro::Case::Result#data` 

**"spec"**

```ruby
Success output: true

result.type == :ok
result.value == true
result.data == { value: true }

# --

Success :created

result.type == :created
result.value == :created
result.data == { created: true }

# --

Success :created, output: { some: :value }

result.type == :created
result.value == { some: :value }
result.data == { some: :value }

# ------------------- -------------------
# ------------------- -------------------
# ------------------- -------------------

Failure output: false

result.type == :error
result.value == false
result.data == { value: false }

# --

Failure :not_found

result.type == :not_found
result.value == :not_found
result.data == { :not_found: true }

# --

Failure :not_found, output: { some: :value }

result.type == :not_found
result.value == { some: :value }
result.data == { some: :value }
```

- [ ] Add the [kind gem](https://github.com/serradura/kind) as a dependency and use it to validate if the reducer argument is a Hash. ([~Waiting for the version 1.0.0~](https://github.com/serradura/kind/pull/12))