### PR TITLE
[2.6.0] Improve the Micro::Case::Result#then method

### DIFF
--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -44,11 +44,10 @@ module Micro
     end
 
     def self.__call_and_set_transition__(result, arg)
-      if arg.respond_to?(:keys)
-        result.__set_transitions_accessible_attributes__(arg.keys)
-      end
+      input =
+        arg.is_a?(Hash) ? result.__set_transitions_accessible_attributes__(arg) : arg
 
-      __new__(result, arg).call
+      __new__(result, input).call
     end
 
     FLOW_STEP = 'Flow_Step'.freeze

--- a/lib/micro/case/flow/reducer.rb
+++ b/lib/micro/case/flow/reducer.rb
@@ -93,7 +93,7 @@ module Micro
               value = result.value
               input = value.is_a?(Hash) ? memo.tap { |data| data.merge!(value) } : value
 
-              result.__set_transitions_accessible_attributes__(memo.keys)
+              result.__set_transitions_accessible_attributes__(memo)
 
               next_use_case_result(use_case, result, input)
             end

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -114,10 +114,6 @@ module Micro
         __set_transitions_accessible_attributes__!(attributes_data)
       end
 
-      def __get_transitions_accessible_attributes__
-        @__transitions_accessible_attributes__
-      end
-
       private
 
         def __set_transitions_accessible_attributes__!(attributes_data)

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -28,7 +28,7 @@ module Micro
       attr_reader :value, :type
 
       def initialize
-        @__transitions__ = {}
+        @__transitions__ = []
         @__transitions_accessible_attributes__ = {}
       end
 
@@ -105,9 +105,7 @@ module Micro
       end
 
       def transitions
-        return [] if @__transitions__.empty?
-
-        @__transitions__.map { |_use_case, transition| transition }
+        @__transitions__.clone
       end
 
       def __set_transitions_accessible_attributes__(attributes_data)
@@ -152,13 +150,12 @@ module Micro
           __update_transitions_accessible_attributes__(use_case_attributes)
 
           result = @success ? :success : :failure
-          transition = {
+
+          @__transitions__ << {
             use_case: { class: use_case_class, attributes: use_case_attributes },
             result => { type: @type, value: @value },
             accessible_attributes: @__transitions_accessible_attributes__.keys
           }
-
-          @__transitions__[use_case_class] = transition
         end
     end
   end

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '2.5.0'.freeze
+    VERSION = '2.6.0'.freeze
   end
 end

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -248,6 +248,28 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_success_result(result1)
 
+    result1_transitions = result1.transitions
+
+    [
+      {
+        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        accessible_attributes: [:foo, :bar]
+      },
+      {
+        use_case: { class: Foo, attributes: { foo: 'foo' } },
+        success: { type: :ok, value: { filled_foo: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo_and_bar]
+      },
+      {
+        use_case: { class: Bar, attributes: { bar: 'bar' }},
+        success: { type: :ok, value: { filled_bar: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :filled_foo]
+      }
+    ].each_with_index do |expected_transition, index|
+      assert_equal(expected_transition, result1_transitions[index])
+    end
+
     # ---
 
     result2 =
@@ -257,6 +279,33 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .then(Bar)
 
     assert_success_result(result2)
+
+    result2_transitions = result2.transitions
+
+    [
+      {
+        use_case: { class: Foo, attributes: { foo: 'foo' } },
+        success: { type: :ok, value: { filled_foo: true } },
+        accessible_attributes: [:foo, :bar]
+      },
+      {
+        use_case: { class: Bar, attributes: { bar: 'bar' }},
+        success: { type: :ok, value: { filled_bar: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo]
+      },
+      {
+        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar]
+      },
+      {
+        use_case: { class: Bar, attributes: { bar: 'bar' }},
+        success: { type: :ok, value: { filled_bar: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :filled_foo_and_bar]
+      },
+    ].each_with_index do |expected_transition, index|
+      assert_equal(expected_transition, result2_transitions[index])
+    end
   end
 
   def test_the_injection_of_values
@@ -267,6 +316,23 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_success_result(result1)
 
+    result1_transitions = result1.transitions
+
+    [
+      {
+        use_case: { class: Foo, attributes: { foo: 'foo' } },
+        success: { type: :ok, value: { filled_foo: true } },
+        accessible_attributes: [:foo]
+      },
+      {
+        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        accessible_attributes: [:foo, :filled_foo, :bar]
+      }
+    ].each_with_index do |expected_transition, index|
+      assert_equal(expected_transition, result1_transitions[index])
+    end
+
     # ---
 
     result2 =
@@ -275,6 +341,23 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .then(FooBar, foo: 'foo')
 
     assert_success_result(result2)
+
+    result2_transitions = result2.transitions
+
+    [
+      {
+        use_case: { class: Bar, attributes: { bar: 'bar' }},
+        success: { type: :ok, value: { filled_bar: true } },
+        accessible_attributes: [:bar]
+      },
+      {
+        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        accessible_attributes: [:bar, :filled_bar, :foo]
+      }
+    ].each_with_index do |expected_transition, index|
+      assert_equal(expected_transition, result2_transitions[index])
+    end
 
     # ---
 
@@ -285,6 +368,23 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_success_result(result3)
 
+    result3_transitions = result3.transitions
+
+    [
+      {
+        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        accessible_attributes: [:foo, :bar]
+      },
+      {
+        use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
+        success: { type: :ok, value: { filled_foo_and_bar_and_baz: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :baz]
+      },
+    ].each_with_index do |expected_transition, index|
+      assert_equal(expected_transition, result3_transitions[index])
+    end
+
     # ---
 
     result4 =
@@ -293,5 +393,27 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .then(FooBarBaz, baz: 'baz')
 
     assert_success_result(result4)
+
+    result4_transitions = result4.transitions
+
+    [
+      {
+        use_case: { class: Foo, attributes: { foo: 'foo' } },
+        success: { type: :ok, value: { filled_foo: true } },
+        accessible_attributes: [:foo, :bar]
+      },
+      {
+        use_case: { class: Bar, attributes: { bar: 'bar' }},
+        success: { type: :ok, value: { filled_bar: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo]
+      },
+      {
+        use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
+        success: { type: :ok, value: { filled_foo_and_bar_and_baz: true } },
+        accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :baz]
+      },
+    ].each_with_index do |expected_transition, index|
+      assert_equal(expected_transition, result4_transitions[index])
+    end
   end
 end

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -89,7 +89,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
       first_transition_use_case = first_transition[:use_case]
 
       # transitions[0][:use_case][:class]
-      assert_equal(Micro::Case::Result::ThenTest::ConvertTextIntoInteger, first_transition_use_case[:class])
+      assert_equal(ConvertTextIntoInteger, first_transition_use_case[:class])
 
       # transitions[0][:use_case][:attributes]
       assert_equal([:text], first_transition_use_case[:attributes].keys)
@@ -123,7 +123,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
       second_transition_use_case = second_transition[:use_case]
 
       # transitions[1][:use_case][:class]
-      assert_equal(Micro::Case::Result::ThenTest::Add3, second_transition_use_case[:class])
+      assert_equal(Add3, second_transition_use_case[:class])
 
       # transitions[1][:use_case][:attributes]
       assert_equal([:number], second_transition_use_case[:attributes].keys)
@@ -165,7 +165,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
       first_transition_use_case = first_transition[:use_case]
 
       # transitions[0][:use_case][:class]
-      assert_equal(Micro::Case::Result::ThenTest::ConvertTextIntoInteger, first_transition_use_case[:class])
+      assert_equal(ConvertTextIntoInteger, first_transition_use_case[:class])
 
       # transitions[0][:use_case][:attributes]
       assert_equal([:text], first_transition_use_case[:attributes].keys)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,7 @@ module MicroCaseAssertions
   def assert_success_result(result, options = { type: :ok })
     value = (block_given? ? yield : options[:value])
 
-    assert_result(result, options.merge(value: value))
+    assert_result(result, options.merge(value: value)) if value
 
     assert_predicate(result, :success?)
 


### PR DESCRIPTION
## Features
- [x] Pass accumulated data when composing a flow using the `Micro::Case::Result#then` method.
- [x] Allow attributes data injection via `Micro::Case::Result#then` method.

![image](https://user-images.githubusercontent.com/305364/86701446-6a012800-bfe8-11ea-9c84-caf01183678b.png)

## Fix
- [x] Fix `Micro::Case::Result#transitions` when calling the same use case in different moments.

### Release Checklist
- [x] Update README
- [x] Bump version to 2.6.0


