### PR TITLE
[3.0.0.pre] Change the API to declare Micro::Case success and failure results

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The main project goals are:
     - [Why the failure hook (without a type) exposes a different kind of data?](#why-the-failure-hook-without-a-type-exposes-a-different-kind-of-data)
     - [What happens if a result hook was declared multiple times?](#what-happens-if-a-result-hook-was-declared-multiple-times)
     - [How to use the `Micro::Case::Result#then` method?](#how-to-use-the-microcaseresultthen-method)
+      - [What does happens when a `Micro::Case::Result#then` receives a block?](#what-does-happens-when-a-microcaseresultthen-receives-a-block)
       - [How to make attributes data injection using this feature?](#how-to-make-attributes-data-injection-using-this-feature)
   - [`Micro::Cases::Flow` - How to compose use cases?](#microcasesflow---how-to-compose-use-cases)
     - [Is it possible to compose a use case flow with other ones?](#is-it-possible-to-compose-a-use-case-flow-with-other-ones)
@@ -474,6 +475,42 @@ result2.success? # true
 ```
 
 > **Note:** this method changes the [`Micro::Case::Result#transitions`](#how-to-understand-what-is-happening-during-a-flow-execution).
+
+[⬆️ Back to Top](#table-of-contents-)
+
+##### What does happens when a `Micro::Case::Result#then` receives a block?
+
+It will yields self (a `Micro::Case::Result instance`) to the block and return the result of the block. e.g:
+
+```ruby
+class Add < Micro::Case
+  attributes :a, :b
+
+  def call!
+    return Success output: { sum: a + b } if Kind.of.Numeric?(a, b)
+
+    Failure(:attributes_arent_numbers)
+  end
+end
+
+# --
+
+success_result =
+  Add
+    .call(a: 2, b: 2)
+    .then { |result| result.success? ? result.value[:sum] : 0 }
+
+puts success_result # 4
+
+# --
+
+failure_result =
+  Add
+    .call(a: 2, b: '2')
+    .then { |result| result.success? ? result.value[:sum] : 0 }
+
+puts failure_result # 0
+```
 
 [⬆️ Back to Top](#table-of-contents-)
 

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -17,12 +17,32 @@ module Micro
 
     include Micro::Attributes.without(:strict_initialize)
 
+    def self.call(options = {})
+      new(options).call
+    end
+
     def self.to_proc
       Proc.new { |arg| call(arg) }
     end
 
-    def self.call(options = {})
-      new(options).call
+    def self.call!
+      self
+    end
+
+    def self.flow(*args)
+      @__flow_use_cases = args
+    end
+
+    def self.inherited(subclass)
+      subclass.attributes(self.attributes_data({}))
+      subclass.extend ::Micro::Attributes.const_get('Macros::ForSubclasses'.freeze)
+
+      if self.send(:__flow_use_cases) && !subclass.name.to_s.end_with?(FLOW_STEP)
+        raise "Wooo, you can't do this! Inherits from a use case which has an inner flow violates "\
+          "one of the project principles: Solve complex business logic, by allowing the composition of use cases. "\
+          "Instead of doing this, declare a new class/constant with the steps needed.\n\n"\
+          "Related issue: https://github.com/serradura/u-case/issues/19\n"
+      end
     end
 
     def self.__new__(result, arg)
@@ -38,51 +58,12 @@ module Micro
       __new__(result, input).call
     end
 
-    FLOW_STEP = 'Flow_Step'.freeze
-
-    private_constant :FLOW_STEP
-
-    def self.__call!
-      return const_get(FLOW_STEP) if const_defined?(FLOW_STEP, false)
-
-      class_eval("class #{FLOW_STEP} < #{self.name}; private def __call; __call_use_case; end; end")
-    end
-
-    def self.call!
-      self
-    end
-
-    def self.inherited(subclass)
-      subclass.attributes(self.attributes_data({}))
-      subclass.extend ::Micro::Attributes.const_get('Macros::ForSubclasses'.freeze)
-
-      if self.send(:__flow_use_cases) && !subclass.name.to_s.end_with?(FLOW_STEP)
-        raise "Wooo, you can't do this! Inherits from a use case which has an inner flow violates "\
-          "one of the project principles: Solve complex business logic, by allowing the composition of use cases. "\
-          "Instead of doing this, declare a new class/constant with the steps needed.\n\n"\
-          "Related issue: https://github.com/serradura/u-case/issues/19\n"
-      end
-    end
-
     def self.__flow_builder
       Cases::Flow
     end
 
     def self.__flow_get
       return @__flow if defined?(@__flow)
-    end
-
-    private_class_method def self.__flow_use_cases
-      return @__flow_use_cases if defined?(@__flow_use_cases)
-    end
-
-    private_class_method def self.__flow_use_cases_get
-      Array(__flow_use_cases)
-        .map { |use_case| use_case == self ? self.__call! : use_case }
-    end
-
-    private_class_method def self.__flow_use_cases_set(args)
-      @__flow_use_cases = args
     end
 
     private_class_method def self.__flow_set(args)
@@ -95,12 +76,27 @@ module Micro
       @__flow = __flow_builder.build(args)
     end
 
-    def self.__flow_set!
-      __flow_set(__flow_use_cases_get) if !__flow_get && __flow_use_cases
+    FLOW_STEP = 'Flow_Step'.freeze
+
+    private_constant :FLOW_STEP
+
+    def self.__call!
+      return const_get(FLOW_STEP) if const_defined?(FLOW_STEP, false)
+
+      class_eval("class #{FLOW_STEP} < #{self.name}; private def __call; __call_use_case; end; end")
     end
 
-    def self.flow(*args)
-      __flow_use_cases_set(args)
+    private_class_method def self.__flow_use_cases
+      return @__flow_use_cases if defined?(@__flow_use_cases)
+    end
+
+    private_class_method def self.__flow_use_cases_get
+      Array(__flow_use_cases)
+        .map { |use_case| use_case == self ? self.__call! : use_case }
+    end
+
+    def self.__flow_set!
+      __flow_set(__flow_use_cases_get) if !__flow_get && __flow_use_cases
     end
 
     def initialize(input)
@@ -154,33 +150,34 @@ module Micro
         self.class.__flow_get.call(@__input)
       end
 
-      def Success(arg = :ok)
-        value, type = block_given? ? [yield, arg] : [arg, :ok]
+      def Success(type = :ok, result: nil)
+        value = result || type
 
-        __get_result_with(true, value, type)
+        __get_result(true, value, type)
       end
 
-      def Failure(arg = :error)
-        value = block_given? ? yield : arg
-        type = __map_failure_type(value, block_given? ? arg : :error)
+      def Failure(type = :error, result: nil)
+        value = result || type
 
-        __get_result_with(false, value, type)
+        type = __map_failure_type(value, type)
+
+        __get_result(false, value, type)
       end
 
-      def __map_failure_type(arg, type)
+      def __map_failure_type(value, type)
         return type if type != :error
-        return arg if arg.is_a?(Symbol)
-        return :exception if arg.is_a?(Exception)
+        return value if value.is_a?(Symbol)
+        return :exception if value.is_a?(Exception)
 
         type
       end
 
-      def __get_result__
+      def __result__
         @__result ||= Result.new
       end
 
-      def __get_result_with(is_success, value, type)
-        __get_result__.__set__(is_success, value, type, self)
+      def __get_result(is_success, value, type)
+        __result__.__set__(is_success, value, type, self)
       end
   end
 end

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -156,20 +156,20 @@ module Micro
         __get_result(true, value, type)
       end
 
-      def Failure(type = :error, result: nil)
-        value = result || type
-
-        type = __map_failure_type(value, type)
-
-        __get_result(false, value, type)
-      end
-
-      def __map_failure_type(value, type)
+      MapFailureType = -> (value, type) do
         return type if type != :error
         return value if value.is_a?(Symbol)
         return :exception if value.is_a?(Exception)
 
         type
+      end
+
+      def Failure(type = :error, result: nil)
+        value = result || type
+
+        type = MapFailureType.call(value, type)
+
+        __get_result(false, value, type)
       end
 
       def __result__
@@ -179,5 +179,7 @@ module Micro
       def __get_result(is_success, value, type)
         __result__.__set__(is_success, value, type, self)
       end
+
+      private_constant :MapFailureType
   end
 end

--- a/lib/micro/case/error.rb
+++ b/lib/micro/case/error.rb
@@ -17,6 +17,10 @@ module Micro
         def initialize; super('type must be a Symbol'.freeze); end
       end
 
+      class InvalidResultValue < TypeError
+        def initialize; super('value must be a Hash, Symbol or an Exception'.freeze); end
+      end
+
       class InvalidResultInstance < ArgumentError
         def initialize; super('argument must be an instance of Micro::Case::Result'.freeze); end
       end
@@ -29,17 +33,13 @@ module Micro
         def initialize; super('Invalid invocation of the Micro::Case::Result#then method'); end
       end
 
-      class UndefinedFlow < ArgumentError
-        def initialize; super("This class hasn't declared its flow. Please, use the `flow()` macro to define one.".freeze); end
-      end
-
       class InvalidAccessToTheUseCaseObject < StandardError
         def initialize; super('only a failure result can access its use case object'.freeze); end
       end
 
       module ByWrongUsage
         def self.check(exception)
-          exception.is_a?(Error::UnexpectedResult) || exception.is_a?(ArgumentError)
+          exception.is_a?(Error::UnexpectedResult) || exception.is_a?(InvalidResultValue) || exception.is_a?(ArgumentError)
         end
       end
     end

--- a/lib/micro/case/error.rb
+++ b/lib/micro/case/error.rb
@@ -17,8 +17,19 @@ module Micro
         def initialize; super('type must be a Symbol'.freeze); end
       end
 
-      class InvalidResultValue < TypeError
-        def initialize; super('value must be a Hash, Symbol or an Exception'.freeze); end
+      class InvalidResultData < TypeError
+      end
+
+      class InvalidSuccessResult < InvalidResultData
+        def initialize(object)
+          super("Success(result: #{object.inspect}) must be a Hash or Symbol")
+        end
+      end
+
+      class InvalidFailureResult < InvalidResultData
+        def initialize(object)
+          super("Failure(result: #{object.inspect}) must be a Hash, Symbol or an Exception")
+        end
       end
 
       class InvalidResultInstance < ArgumentError
@@ -37,10 +48,8 @@ module Micro
         def initialize; super('only a failure result can access its use case object'.freeze); end
       end
 
-      module ByWrongUsage
-        def self.check(exception)
-          exception.is_a?(Error::UnexpectedResult) || exception.is_a?(InvalidResultValue) || exception.is_a?(ArgumentError)
-        end
+      def self.by_wrong_usage?(exception)
+        exception.is_a?(InvalidResultData) || exception.is_a?(Error::UnexpectedResult) || exception.is_a?(ArgumentError)
       end
     end
   end

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -155,7 +155,7 @@ module Micro
 
           @__transitions__ << {
             use_case: { class: use_case_class, attributes: use_case_attributes },
-            result => { type: @type, value: data },
+            result => { type: @type, result: data },
             accessible_attributes: @__transitions_accessible_attributes__.keys
           }
         end

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -13,23 +13,15 @@ module Micro
         @@transition_tracking_disabled = true
       end
 
-      class Data
-        attr_reader :value, :type
-
-        def initialize(value, type)
-          @value, @type = value, type
-        end
-
-        def to_ary; [value, type]; end
-      end
-
-      private_constant :Data
-
       attr_reader :value, :type
 
       def initialize
         @__transitions__ = []
         @__transitions_accessible_attributes__ = {}
+      end
+
+      def to_ary
+        [value, type]
       end
 
       def __set__(is_success, value, type, use_case)
@@ -66,7 +58,7 @@ module Micro
       def on_failure(expected_type = nil)
         return self unless failure_type?(expected_type)
 
-        data = expected_type.nil? ? Data.new(value, type).tap(&:freeze) : value
+        data = expected_type.nil? ? self : value
 
         yield(data, @use_case)
 

--- a/lib/micro/case/safe.rb
+++ b/lib/micro/case/safe.rb
@@ -10,7 +10,7 @@ module Micro
       def call
         __call
       rescue => exception
-        raise exception if Error::ByWrongUsage.check(exception)
+        raise exception if Error.by_wrong_usage?(exception)
 
         Failure(result: exception)
       end

--- a/lib/micro/case/safe.rb
+++ b/lib/micro/case/safe.rb
@@ -3,12 +3,16 @@
 module Micro
   class Case
     class Safe < ::Micro::Case
+      def self.__flow_builder
+        Cases::Safe::Flow
+      end
+
       def call
         __call
       rescue => exception
         raise exception if Error::ByWrongUsage.check(exception)
 
-        Failure(exception)
+        Failure(result: exception)
       end
     end
   end

--- a/lib/micro/case/with_activemodel_validation.rb
+++ b/lib/micro/case/with_activemodel_validation.rb
@@ -35,7 +35,7 @@ module Micro
       def failure_by_validation_error(object)
         errors = object.respond_to?(:errors) ? object.errors : object
 
-        Failure(:validation_error) { { errors: errors } }
+        Failure :validation_error, result: { errors: errors }
       end
   end
 end

--- a/lib/micro/cases/flow.rb
+++ b/lib/micro/cases/flow.rb
@@ -84,7 +84,7 @@ module Micro
           @next_use_cases.reduce(first_result) do |result, use_case|
             break result if result.failure?
 
-            memo.merge!(result.data)
+            memo.merge!(result.value)
 
             result.__set_transitions_accessible_attributes__(memo)
 

--- a/lib/micro/cases/flow.rb
+++ b/lib/micro/cases/flow.rb
@@ -84,12 +84,11 @@ module Micro
           @next_use_cases.reduce(first_result) do |result, use_case|
             break result if result.failure?
 
-            value = result.value
-            input = value.is_a?(Hash) ? memo.tap { |data| data.merge!(value) } : value
+            memo.merge!(result.data)
 
             result.__set_transitions_accessible_attributes__(memo)
 
-            next_use_case_result(use_case, result, input)
+            next_use_case_result(use_case, result, memo)
           end
         end
     end

--- a/lib/micro/cases/safe/flow.rb
+++ b/lib/micro/cases/safe/flow.rb
@@ -8,7 +8,7 @@ module Micro
           instance = use_case.__new__(result, input)
           instance.call
         rescue => exception
-          raise exception if Case::Error::ByWrongUsage.check(exception)
+          raise exception if Case::Error.by_wrong_usage?(exception)
 
           result.__set__(false, exception, :exception, instance)
         end

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -36,19 +36,37 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     end
 
     def test_the_method_then_with_a_block
-      result1 = success_result(value: 0)
-      result2 = failure_result(value: 1)
+      success = success_result(value: 0)
+      success_incr = 0
 
-      result1.then { |result| assert_equal(result1, result) }
-      result2.then { |result| assert_equal(result2, result) }
+      then_output1 =
+      success.then { |result| result.success? ? success_incr += 1 : 0 }
+
+      refute_instance_of(Micro::Case::Result, then_output1)
+      assert_equal(success_incr, then_output1)
+
+      # ---
+
+      failure = failure_result(value: 1)
+      failure_incr = 0
+
+      then_output2 =
+        failure.then { |result| result.failure? ? failure_incr += 1 : 0 }
+
+      refute_instance_of(Micro::Case::Result, then_output2)
+      assert_equal(failure_incr, then_output2)
     end
 
     def test_the_method_then_without_a_block_or_an_argument
-      result1 = success_result(value: 0)
-      result2 = failure_result(value: 1)
+      success = success_result(value: 0)
 
-      assert_instance_of(Enumerator, result1.then)
-      assert_instance_of(Enumerator, result2.then)
+      assert_instance_of(Enumerator, success.then)
+
+      # ---
+
+      failure = failure_result(value: 1)
+
+      assert_instance_of(Enumerator, failure.then)
     end
   end
 
@@ -77,74 +95,29 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_success_result(result1, value: { number: 3 })
 
-    result1.transitions.tap do |result_transitions|
-      assert_equal(2, result_transitions.size)
+    expected_transitions1 = [
+      {
+        use_case: {
+          class: ConvertTextIntoInteger, attributes: { text: '0'}
+        },
+        success: {
+          type: :ok, value: { number: 0 }
+        },
+        accessible_attributes: [:text]
+      },
+      {
+        use_case: {
+          class: Add3, attributes: { number: 0 }
+        },
+        success: {
+          type: :ok, value: { number: 3 }
+        },
+        accessible_attributes: [:text, :number]
+      }
+    ]
 
-      # --------------
-      # transitions[0]
-      # --------------
-      first_transition = result_transitions[0]
-
-      # transitions[0][:use_case]
-      first_transition_use_case = first_transition[:use_case]
-
-      # transitions[0][:use_case][:class]
-      assert_equal(ConvertTextIntoInteger, first_transition_use_case[:class])
-
-      # transitions[0][:use_case][:attributes]
-      assert_equal([:text], first_transition_use_case[:attributes].keys)
-
-      assert_equal('0', first_transition_use_case[:attributes][:text])
-
-      # transitions[0][:success]
-      assert(first_transition.include?(:success))
-
-      first_transition_result = first_transition[:success]
-
-      # transitions[0][:success][:type]
-      assert_equal(:ok, first_transition_result[:type])
-
-      # transitions[0][:success][:value]
-      assert_equal([:number], first_transition_result[:value].keys)
-
-      assert_equal(0, first_transition_result[:value][:number])
-
-      # transitions[0][:accessible_attributes]
-      assert_equal([:text], first_transition[:accessible_attributes])
-
-      # --------------
-      # transitions[1]
-      # --------------
-
-      second_transition = result_transitions[1]
-
-      # transitions[1][:use_case]
-
-      second_transition_use_case = second_transition[:use_case]
-
-      # transitions[1][:use_case][:class]
-      assert_equal(Add3, second_transition_use_case[:class])
-
-      # transitions[1][:use_case][:attributes]
-      assert_equal([:number], second_transition_use_case[:attributes].keys)
-
-      assert_equal(0, second_transition_use_case[:attributes][:number])
-
-      # transitions[1][:success]
-      assert(second_transition.include?(:success))
-
-      second_transition_result = second_transition[:success]
-
-      # transitions[1][:success][:type]
-      assert_equal(:ok, second_transition_result[:type])
-
-      # transitions[1][:success][:value]
-      assert_equal([:number], second_transition_result[:value].keys)
-
-      assert_equal(3, second_transition_result[:value][:number])
-
-      # transitions[1][:accessible_attributes]
-      assert_equal([:text, :number], second_transition[:accessible_attributes])
+    result1.transitions.each_with_index do |transition, index|
+      assert_equal(expected_transitions1[index], transition)
     end
 
     # ---
@@ -153,39 +126,21 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_failure_result(result2, value: :text_isnt_a_string_only_with_numbers)
 
-    result2.transitions.tap do |result_transitions|
-      assert_equal(1, result_transitions.size)
+    expected_transitions2 = [
+      {
+        use_case: {
+          class: ConvertTextIntoInteger, attributes: { text: 0}
+        },
+        failure: {
+          type: :text_isnt_a_string_only_with_numbers,
+          value: :text_isnt_a_string_only_with_numbers
+        },
+        accessible_attributes: [:text]
+      }
+    ]
 
-      # --------------
-      # transitions[0]
-      # --------------
-      first_transition = result_transitions[0]
-
-      # transitions[0][:use_case]
-      first_transition_use_case = first_transition[:use_case]
-
-      # transitions[0][:use_case][:class]
-      assert_equal(ConvertTextIntoInteger, first_transition_use_case[:class])
-
-      # transitions[0][:use_case][:attributes]
-      assert_equal([:text], first_transition_use_case[:attributes].keys)
-
-      assert_equal(0, first_transition_use_case[:attributes][:text])
-
-      # transitions[0][:success]
-      assert(first_transition.include?(:failure))
-
-      first_transition_result = first_transition[:failure]
-
-      # transitions[0][:success][:type]
-      assert_equal(:text_isnt_a_string_only_with_numbers, first_transition_result[:type])
-
-      # transitions[0][:success][:value]
-
-      assert_equal(:text_isnt_a_string_only_with_numbers, first_transition_result[:value])
-
-      # transitions[0][:accessible_attributes]
-      assert_equal([:text], first_transition[:accessible_attributes])
+    result2.transitions.each_with_index do |transition, index|
+      assert_equal(expected_transitions2[index], transition)
     end
   end
 

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -17,8 +17,8 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
   if RUBY_VERSION < '2.5.0'
     def test_the_not_implemented_error
-      result1 = success_result(value: 0)
-      result2 = failure_result(value: 1)
+      result1 = success_result(value: {number: 0})
+      result2 = failure_result(value: {number: 1})
 
       assert_raises(NotImplementedError) { result1.then { 0 } }
       assert_raises(NotImplementedError) { result2.then { 0 } }
@@ -28,15 +28,15 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     end
   else
     def test_the_not_implemented_error
-      result1 = success_result(value: 0)
-      result2 = failure_result(value: 1)
+      result1 = success_result(value: {number: 0})
+      result2 = failure_result(value: {number: 1})
 
       assert_raises(Micro::Case::Error::InvalidInvocationOfTheThenMethod) { result1.then(1) { 0 } }
       assert_raises(Micro::Case::Error::InvalidInvocationOfTheThenMethod) { result2.then(1) { 0 } }
     end
 
     def test_the_method_then_with_a_block
-      success = success_result(value: 0)
+      success = success_result(value: {number: 0})
       success_incr = 0
 
       then_output1 =
@@ -47,7 +47,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
       # ---
 
-      failure = failure_result(value: 1)
+      failure = failure_result(value: {number: 1})
       failure_incr = 0
 
       then_output2 =
@@ -58,13 +58,13 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     end
 
     def test_the_method_then_without_a_block_or_an_argument
-      success = success_result(value: 0)
+      success = success_result(value: {number: 0})
 
       assert_instance_of(Enumerator, success.then)
 
       # ---
 
-      failure = failure_result(value: 1)
+      failure = failure_result(value: {number: 1})
 
       assert_instance_of(Enumerator, failure.then)
     end
@@ -101,7 +101,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
           class: ConvertTextIntoInteger, attributes: { text: '0'}
         },
         success: {
-          type: :ok, value: { number: 0 }, data: { number: 0 }
+          type: :ok, value: { number: 0 }
         },
         accessible_attributes: [:text]
       },
@@ -110,7 +110,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
           class: Add3, attributes: { number: 0 }
         },
         success: {
-          type: :ok, value: { number: 3 }, data: { number: 3 }
+          type: :ok, value: { number: 3 }
         },
         accessible_attributes: [:text, :number]
       }
@@ -124,7 +124,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result2 = ConvertTextIntoInteger.call(text: 0).then(Add3)
 
-    assert_failure_result(result2, value: :text_isnt_a_string_only_with_numbers)
+    assert_failure_result(result2, value: { text_isnt_a_string_only_with_numbers: true })
 
     expected_transitions2 = [
       {
@@ -133,8 +133,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         },
         failure: {
           type: :text_isnt_a_string_only_with_numbers,
-          value: :text_isnt_a_string_only_with_numbers,
-          data: {text_isnt_a_string_only_with_numbers: true}
+          value: { text_isnt_a_string_only_with_numbers: true }
         },
         accessible_attributes: [:text]
       }
@@ -146,8 +145,8 @@ class Micro::Case::Result::ThenTest < Minitest::Test
   end
 
   def test_the_not_implemented_error_when_call_the_method_then_without_an_use_case
-    result1 = success_result(value: 0)
-    result2 = failure_result(value: 1)
+    result1 = success_result(value: {number: 0})
+    result2 = failure_result(value: {number: 1})
 
     assert_raises(Micro::Case::Error::InvalidInvocationOfTheThenMethod) { result1.then(1) }
     assert_raises(Micro::Case::Error::InvalidInvocationOfTheThenMethod) { result2.then(1) }
@@ -209,17 +208,17 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
+        success: { type: :filled_foo, value: { filled_foo: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
+        success: { type: :filled_bar, value: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :filled_foo]
       }
     ].each_with_index do |expected_transition, index|
@@ -241,22 +240,22 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
+        success: { type: :filled_foo, value: { filled_foo: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
+        success: { type: :filled_bar, value: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
+        success: { type: :filled_bar, value: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :filled_foo_and_bar]
       },
     ].each_with_index do |expected_transition, index|
@@ -277,12 +276,12 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
+        success: { type: :filled_foo, value: { filled_foo: true } },
         accessible_attributes: [:foo]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :filled_foo, :bar]
       }
     ].each_with_index do |expected_transition, index|
@@ -303,12 +302,12 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
+        success: { type: :filled_bar, value: { filled_bar: true } },
         accessible_attributes: [:bar]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
         accessible_attributes: [:bar, :filled_bar, :foo]
       }
     ].each_with_index do |expected_transition, index|
@@ -329,12 +328,12 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :filled_foo_and_bar_and_baz, value: :filled_foo_and_bar_and_baz, data: { filled_foo_and_bar_and_baz: true } },
+        success: { type: :filled_foo_and_bar_and_baz, value: { filled_foo_and_bar_and_baz: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :baz]
       },
     ].each_with_index do |expected_transition, index|
@@ -355,17 +354,17 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
+        success: { type: :filled_foo, value: { filled_foo: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
+        success: { type: :filled_bar, value: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo]
       },
       {
         use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :filled_foo_and_bar_and_baz, value: :filled_foo_and_bar_and_baz, data: { filled_foo_and_bar_and_baz: true } },
+        success: { type: :filled_foo_and_bar_and_baz, value: { filled_foo_and_bar_and_baz: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :baz]
       },
     ].each_with_index do |expected_transition, index|

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -101,7 +101,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
           class: ConvertTextIntoInteger, attributes: { text: '0'}
         },
         success: {
-          type: :ok, value: { number: 0 }
+          type: :ok, value: { number: 0 }, data: { number: 0 }
         },
         accessible_attributes: [:text]
       },
@@ -110,7 +110,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
           class: Add3, attributes: { number: 0 }
         },
         success: {
-          type: :ok, value: { number: 3 }
+          type: :ok, value: { number: 3 }, data: { number: 3 }
         },
         accessible_attributes: [:text, :number]
       }
@@ -133,7 +133,8 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         },
         failure: {
           type: :text_isnt_a_string_only_with_numbers,
-          value: :text_isnt_a_string_only_with_numbers
+          value: :text_isnt_a_string_only_with_numbers,
+          data: {text_isnt_a_string_only_with_numbers: true}
         },
         accessible_attributes: [:text]
       }
@@ -156,7 +157,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :foo, :bar
 
     def call!
-      return Success(result: { filled_foo_and_bar: true }) if foo && bar
+      return Success(:filled_foo_and_bar) if foo && bar
 
       Failure(:missing_foo_or_bar)
     end
@@ -166,7 +167,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :foo
 
     def call!
-      return Success(result: { filled_foo: true }) if foo
+      return Success(:filled_foo) if foo
 
       Failure(:missing_foo)
     end
@@ -176,7 +177,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :bar
 
     def call!
-      return Success(result: { filled_bar: true }) if bar
+      return Success(:filled_bar) if bar
 
       Failure(:missing_bar)
     end
@@ -188,7 +189,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :foo, :bar, :baz
 
     def call!
-      return Success(result: { filled_foo_and_bar_and_baz: true }) if foo && bar && baz
+      return Success(:filled_foo_and_bar_and_baz) if foo && bar && baz
 
       Failure(:missing_foo_or_bar_or_baz)
     end
@@ -201,24 +202,24 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .then(Foo)
         .then(Bar)
 
-    assert_success_result(result1)
+    assert_success_result(result1, type: :filled_bar)
 
     result1_transitions = result1.transitions
 
     [
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :ok, value: { filled_foo: true } },
+        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :ok, value: { filled_bar: true } },
+        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :filled_foo]
       }
     ].each_with_index do |expected_transition, index|
@@ -233,29 +234,29 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .then(FooBar)
         .then(Bar)
 
-    assert_success_result(result2)
+    assert_success_result(result2, type: :filled_bar)
 
     result2_transitions = result2.transitions
 
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :ok, value: { filled_foo: true } },
+        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :ok, value: { filled_bar: true } },
+        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :ok, value: { filled_bar: true } },
+        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :filled_foo_and_bar]
       },
     ].each_with_index do |expected_transition, index|
@@ -269,19 +270,19 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .call(foo: 'foo')
         .then(FooBar, bar: 'bar')
 
-    assert_success_result(result1)
+    assert_success_result(result1, type: :filled_foo_and_bar)
 
     result1_transitions = result1.transitions
 
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :ok, value: { filled_foo: true } },
+        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
         accessible_attributes: [:foo]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :filled_foo, :bar]
       }
     ].each_with_index do |expected_transition, index|
@@ -295,19 +296,19 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .call(bar: 'bar')
         .then(FooBar, foo: 'foo')
 
-    assert_success_result(result2)
+    assert_success_result(result2, type: :filled_foo_and_bar)
 
     result2_transitions = result2.transitions
 
     [
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :ok, value: { filled_bar: true } },
+        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
         accessible_attributes: [:bar]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
         accessible_attributes: [:bar, :filled_bar, :foo]
       }
     ].each_with_index do |expected_transition, index|
@@ -321,19 +322,19 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .call(foo: 'foo', bar: 'bar')
         .then(FooBarBaz, baz: 'baz')
 
-    assert_success_result(result3)
+    assert_success_result(result3, type: :filled_foo_and_bar_and_baz)
 
     result3_transitions = result3.transitions
 
     [
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :ok, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, value: :filled_foo_and_bar, data: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :ok, value: { filled_foo_and_bar_and_baz: true } },
+        success: { type: :filled_foo_and_bar_and_baz, value: :filled_foo_and_bar_and_baz, data: { filled_foo_and_bar_and_baz: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :baz]
       },
     ].each_with_index do |expected_transition, index|
@@ -347,24 +348,24 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         .call(foo: 'foo', bar: 'bar')
         .then(FooBarBaz, baz: 'baz')
 
-    assert_success_result(result4)
+    assert_success_result(result4, type: :filled_foo_and_bar_and_baz)
 
     result4_transitions = result4.transitions
 
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :ok, value: { filled_foo: true } },
+        success: { type: :filled_foo, value: :filled_foo, data: { filled_foo: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :ok, value: { filled_bar: true } },
+        success: { type: :filled_bar, value: :filled_bar, data: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo]
       },
       {
         use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :ok, value: { filled_foo_and_bar_and_baz: true } },
+        success: { type: :filled_foo_and_bar_and_baz, value: :filled_foo_and_bar_and_baz, data: { filled_foo_and_bar_and_baz: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :baz]
       },
     ].each_with_index do |expected_transition, index|

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -75,7 +75,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     def call!
       if Kind.of.String?(text) && text =~ /\A\d+\z/
-        Success { { number: text.to_i } }
+        Success result: { number: text.to_i }
       else
         Failure(:text_isnt_a_string_only_with_numbers)
       end
@@ -86,7 +86,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attribute :number
 
     def call!
-      Success { { number: number + 3 } }
+      Success result: { number: number + 3 }
     end
   end
 
@@ -156,7 +156,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :foo, :bar
 
     def call!
-      return Success(filled_foo_and_bar: true) if foo && bar
+      return Success(result: { filled_foo_and_bar: true }) if foo && bar
 
       Failure(:missing_foo_or_bar)
     end
@@ -166,7 +166,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :foo
 
     def call!
-      return Success(filled_foo: true) if foo
+      return Success(result: { filled_foo: true }) if foo
 
       Failure(:missing_foo)
     end
@@ -176,7 +176,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :bar
 
     def call!
-      return Success(filled_bar: true) if bar
+      return Success(result: { filled_bar: true }) if bar
 
       Failure(:missing_bar)
     end
@@ -188,7 +188,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     attributes :foo, :bar, :baz
 
     def call!
-      return Success(filled_foo_and_bar_and_baz: true) if foo && bar && baz
+      return Success(result: { filled_foo_and_bar_and_baz: true }) if foo && bar && baz
 
       Failure(:missing_foo_or_bar_or_baz)
     end

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -101,7 +101,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
           class: ConvertTextIntoInteger, attributes: { text: '0'}
         },
         success: {
-          type: :ok, value: { number: 0 }
+          type: :ok, result: { number: 0 }
         },
         accessible_attributes: [:text]
       },
@@ -110,7 +110,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
           class: Add3, attributes: { number: 0 }
         },
         success: {
-          type: :ok, value: { number: 3 }
+          type: :ok, result: { number: 3 }
         },
         accessible_attributes: [:text, :number]
       }
@@ -133,7 +133,7 @@ class Micro::Case::Result::ThenTest < Minitest::Test
         },
         failure: {
           type: :text_isnt_a_string_only_with_numbers,
-          value: { text_isnt_a_string_only_with_numbers: true }
+          result: { text_isnt_a_string_only_with_numbers: true }
         },
         accessible_attributes: [:text]
       }
@@ -208,17 +208,17 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: { filled_foo: true } },
+        success: { type: :filled_foo, result: { filled_foo: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: { filled_bar: true } },
+        success: { type: :filled_bar, result: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :filled_foo]
       }
     ].each_with_index do |expected_transition, index|
@@ -240,22 +240,22 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: { filled_foo: true } },
+        success: { type: :filled_foo, result: { filled_foo: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: { filled_bar: true } },
+        success: { type: :filled_bar, result: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: { filled_bar: true } },
+        success: { type: :filled_bar, result: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :filled_foo_and_bar]
       },
     ].each_with_index do |expected_transition, index|
@@ -276,12 +276,12 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: { filled_foo: true } },
+        success: { type: :filled_foo, result: { filled_foo: true } },
         accessible_attributes: [:foo]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :filled_foo, :bar]
       }
     ].each_with_index do |expected_transition, index|
@@ -302,12 +302,12 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: { filled_bar: true } },
+        success: { type: :filled_bar, result: { filled_bar: true } },
         accessible_attributes: [:bar]
       },
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
         accessible_attributes: [:bar, :filled_bar, :foo]
       }
     ].each_with_index do |expected_transition, index|
@@ -328,12 +328,12 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, value: { filled_foo_and_bar: true } },
+        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :filled_foo_and_bar_and_baz, value: { filled_foo_and_bar_and_baz: true } },
+        success: { type: :filled_foo_and_bar_and_baz, result: { filled_foo_and_bar_and_baz: true } },
         accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :baz]
       },
     ].each_with_index do |expected_transition, index|
@@ -354,17 +354,17 @@ class Micro::Case::Result::ThenTest < Minitest::Test
     [
       {
         use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, value: { filled_foo: true } },
+        success: { type: :filled_foo, result: { filled_foo: true } },
         accessible_attributes: [:foo, :bar]
       },
       {
         use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, value: { filled_bar: true } },
+        success: { type: :filled_bar, result: { filled_bar: true } },
         accessible_attributes: [:foo, :bar, :filled_foo]
       },
       {
         use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :filled_foo_and_bar_and_baz, value: { filled_foo_and_bar_and_baz: true } },
+        success: { type: :filled_foo_and_bar_and_baz, result: { filled_foo_and_bar_and_baz: true } },
         accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :baz]
       },
     ].each_with_index do |expected_transition, index|

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -47,7 +47,7 @@ class Micro::Case::ResultTest < Minitest::Test
     assert_equal(result.transitions, [
       {
         use_case: { class: Micro::Case, attributes: {} },
-        success: { type: :ok, value: 1 },
+        success: { type: :ok, value: 1, data: { value: 1 } },
         accessible_attributes: []
       }
     ])
@@ -84,7 +84,7 @@ class Micro::Case::ResultTest < Minitest::Test
     assert_equal(result.transitions, [
       {
         use_case: { class: Micro::Case, attributes: {} },
-        failure: { type: :error, value: 0 },
+        failure: { type: :error, value: 0, data: { value: 0 } },
         accessible_attributes: []
       }
     ])

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -18,10 +18,10 @@ class Micro::Case::ResultTest < Minitest::Test
   end
 
   def test_success_result
-    result = success_result(value: { number: 1 }, type: :ok)
+    result = success_result(value: { a: 1, b: 2 }, type: :ok)
 
     assert_predicate(result, :success?)
-    assert_equal(1, result.value[:number])
+    assert_equal(1, result.value[:a])
 
     assert_raises_with_message(
       Micro::Case::Error::InvalidAccessToTheUseCaseObject,
@@ -35,7 +35,7 @@ class Micro::Case::ResultTest < Minitest::Test
       result
         .on_failure { raise }
         .on_success { assert(true) }
-        .on_success { |(value, _type)| assert_equal(1, value[:number]) }
+        .on_success { |(value, _type)| assert_equal(1, value[:a]) }
     )
 
     # ---
@@ -47,21 +47,28 @@ class Micro::Case::ResultTest < Minitest::Test
     assert_equal(result.transitions, [
       {
         use_case: { class: Micro::Case, attributes: {} },
-        success: { type: :ok, result: { number: 1 } },
+        success: { type: :ok, result: { a: 1, b: 2 } },
         accessible_attributes: []
       }
     ])
+
+    # ---
+
+    assert_equal(1, result[:a])
+
+    assert_equal([1], result.values_at(:a))
+    assert_equal([2, 1], result.values_at(:b, :a))
   end
 
   def test_failure_result
     use_case = Micro::Case.new({})
 
-    result = failure_result(value: { number: 0 }, type: :error, use_case: use_case)
+    result = failure_result(value: { a: 0, b: -1 }, type: :error, use_case: use_case)
 
     refute_predicate(result, :success?)
     assert_predicate(result, :failure?)
 
-    assert_equal(0, result.value[:number])
+    assert_equal(0, result.value[:a])
     assert_same(use_case, result.use_case)
 
     # ---
@@ -70,7 +77,7 @@ class Micro::Case::ResultTest < Minitest::Test
       result,
       result
         .on_failure { assert(true) }
-        .on_failure { |data| assert_equal(0, data.value[:number]) }
+        .on_failure { |data| assert_equal(0, data.value[:a]) }
         .on_failure { |_data, ucase| assert_same(ucase, use_case) }
         .on_success { raise }
     )
@@ -84,10 +91,17 @@ class Micro::Case::ResultTest < Minitest::Test
     assert_equal(result.transitions, [
       {
         use_case: { class: Micro::Case, attributes: {} },
-        failure: { type: :error, result: { number: 0 } },
+        failure: { type: :error, result: { a: 0, b: -1 } },
         accessible_attributes: []
       }
     ])
+
+    # ---
+
+    assert_equal(0, result[:a])
+
+    assert_equal([0], result.values_at(:a))
+    assert_equal([-1, 0], result.values_at(:b, :a))
   end
 
   def test_the_result_value

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -47,7 +47,7 @@ class Micro::Case::ResultTest < Minitest::Test
     assert_equal(result.transitions, [
       {
         use_case: { class: Micro::Case, attributes: {} },
-        success: { type: :ok, value: { number: 1 } },
+        success: { type: :ok, result: { number: 1 } },
         accessible_attributes: []
       }
     ])
@@ -84,7 +84,7 @@ class Micro::Case::ResultTest < Minitest::Test
     assert_equal(result.transitions, [
       {
         use_case: { class: Micro::Case, attributes: {} },
-        failure: { type: :error, value: { number: 0 } },
+        failure: { type: :error, result: { number: 0 } },
         accessible_attributes: []
       }
     ])

--- a/test/micro/case/safe/with_inner_flow_test.rb
+++ b/test/micro/case/safe/with_inner_flow_test.rb
@@ -5,7 +5,7 @@ class Micro::Case::Safe::WithInnerFlowTest < Minitest::Test
     attribute :text
 
     def call!
-      Success { { number: text.to_i } }
+      Success result: { number: text.to_i }
     end
   end
 
@@ -13,7 +13,7 @@ class Micro::Case::Safe::WithInnerFlowTest < Minitest::Test
     attribute :number
 
     def call!
-      Success { { text: number.to_s } }
+      Success result: { text: number.to_s }
     end
   end
 
@@ -25,7 +25,7 @@ class Micro::Case::Safe::WithInnerFlowTest < Minitest::Test
     attribute :number
 
     def call!
-      Success { { number: number * 2 } }
+      Success result: { number: number * 2 }
     end
   end
 

--- a/test/micro/case/safe_test.rb
+++ b/test/micro/case/safe_test.rb
@@ -6,7 +6,7 @@ class Micro::Case::SafeTest < Minitest::Test
 
     def call!
       if a.is_a?(Integer) && b.is_a?(Integer)
-        Success(a / b)
+        Success(result: a / b)
       else
         Failure(:not_an_integer)
       end
@@ -81,9 +81,9 @@ class Micro::Case::SafeTest < Minitest::Test
     attribute :arg
 
     def call!
-      Success(2 / arg)
+      Success result: 2 / arg
     rescue => e
-      Failure(e)
+      Failure result: e
     end
   end
 
@@ -91,9 +91,9 @@ class Micro::Case::SafeTest < Minitest::Test
     attribute :arg
 
     def call!
-      Success(2 / arg)
+      Success(result: 2 / arg)
     rescue => e
-      Failure { e }
+      Failure result: e
     end
   end
 
@@ -101,9 +101,9 @@ class Micro::Case::SafeTest < Minitest::Test
     attribute :arg
 
     def call!
-      Success(2 / arg)
+      Success(result: 2 / arg)
     rescue => e
-      Failure(:foo) { e }
+      Failure :foo, result: e
     end
   end
 
@@ -111,9 +111,9 @@ class Micro::Case::SafeTest < Minitest::Test
     attribute :arg
 
     def call!
-      Failure(arg / 0)
+      Failure(result: arg / 0)
     rescue => e
-      Success(e)
+      Success(result: e)
     end
   end
 

--- a/test/micro/case/safe_test.rb
+++ b/test/micro/case/safe_test.rb
@@ -6,7 +6,7 @@ class Micro::Case::SafeTest < Minitest::Test
 
     def call!
       if a.is_a?(Integer) && b.is_a?(Integer)
-        Success(result: a / b)
+        Success(result: { number: a / b })
       else
         Failure(:not_an_integer)
       end
@@ -16,25 +16,25 @@ class Micro::Case::SafeTest < Minitest::Test
   def test_instance_call_method
     result = Divide.new(a: 2, b: 2).call
 
-    assert_success_result(result, value: 1)
+    assert_success_result(result, value: { number: 1 })
 
     # ---
 
     result = Divide.new(a: 2.0, b: 2).call
 
-    assert_failure_result(result, value: :not_an_integer, type: :not_an_integer)
+    assert_failure_result(result, type: :not_an_integer, value: { not_an_integer: true })
   end
 
   def test_class_call_method
-    result = Divide.call(a: 2, b: 2)
+    result = Divide.call(a: 4, b: 2)
 
-    assert_success_result(result, value: 1)
+    assert_success_result(result, { number: 2 })
 
     # ---
 
     result = Divide.call(a: 2.0, b: 2)
 
-    assert_failure_result(result, value: :not_an_integer, type: :not_an_integer)
+    assert_failure_result(result, type: :not_an_integer, value: { not_an_integer: true })
   end
 
   class Foo < Micro::Case::Safe
@@ -73,7 +73,7 @@ class Micro::Case::SafeTest < Minitest::Test
       Divide.new(a: 2, b: 0).call,
       Divide.call(a: 2, b: 0)
     ].each do |result|
-      assert_exception_result(result, value: ZeroDivisionError)
+      assert_exception_result(result, value: { exception: ZeroDivisionError })
     end
   end
 
@@ -122,27 +122,27 @@ class Micro::Case::SafeTest < Minitest::Test
       Divide2ByArgV1.call(arg: 0),
       Divide2ByArgV2.call(arg: 0)
     ].each do |result|
-      assert_exception_result(result, value: ZeroDivisionError)
+      assert_exception_result(result, value: { exception: ZeroDivisionError })
     end
 
     # ---
 
     result = Divide2ByArgV3.call(arg: 0)
 
-    assert_exception_result(result, value: ZeroDivisionError, type: :foo)
+    assert_exception_result(result, type: :foo, value: { exception: ZeroDivisionError })
 
     # ---
 
     result = GenerateZeroDivisionError.call(arg: 2)
     assert_success_result(result)
 
-    assert_kind_of(ZeroDivisionError, result.value)
+    assert_kind_of(ZeroDivisionError, result.value[:exception])
   end
 
   def test_that_when_a_failure_result_is_a_symbol_both_type_and_value_will_be_the_same
     result = Divide.call(a: 2, b: 'a')
 
-    assert_failure_result(result, value: :not_an_integer)
+    assert_failure_result(result, value: { not_an_integer: true })
   end
 
   def test_to_proc
@@ -155,6 +155,9 @@ class Micro::Case::SafeTest < Minitest::Test
 
     values = results.map(&:value)
 
-    assert_equal([1, 2, 3, 4], values)
+    assert_equal(
+      [{number: 1}, {number: 2}, {number: 3}, {number: 4}],
+      values
+    )
   end
 end

--- a/test/micro/case/strict/safe_test.rb
+++ b/test/micro/case/strict/safe_test.rb
@@ -6,7 +6,7 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
 
     def call!
       if a.is_a?(Numeric) && b.is_a?(Numeric)
-        Success(a * b)
+        Success result: a * b
       else
         Failure(:invalid_data)
       end
@@ -17,7 +17,7 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
     attributes :number
 
     def call!
-      return Failure { 'number must be greater than 0' } if number <= 0
+      return Failure result: 'number must be greater than 0' if number <= 0
 
       Multiply.call(a: number, b: number)
     end
@@ -87,7 +87,7 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
 
     def call!
       if a.is_a?(Integer) && b.is_a?(Integer)
-        Success(a / b)
+        Success(result: a / b)
       else
         Failure(:not_an_integer)
       end

--- a/test/micro/case/strict/safe_test.rb
+++ b/test/micro/case/strict/safe_test.rb
@@ -6,7 +6,7 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
 
     def call!
       if a.is_a?(Numeric) && b.is_a?(Numeric)
-        Success result: a * b
+        Success result: { number: a * b }
       else
         Failure(:invalid_data)
       end
@@ -17,30 +17,30 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
     attributes :number
 
     def call!
-      return Failure result: 'number must be greater than 0' if number <= 0
+      return Multiply.call(a: number, b: number) if number > 0
 
-      Multiply.call(a: number, b: number)
+      Failure result: { message: 'number must be greater than 0' }
     end
   end
 
   def test_instance_call_method
     result = Multiply.new(a: 2, b: 2).call
 
-    assert_success_result(result, value: 4)
+    assert_success_result(result, value: { number: 4 })
 
     result = Multiply.new(a: 1, b: '1').call
 
-    assert_failure_result(result, value: :invalid_data, type: :invalid_data)
+    assert_failure_result(result, type: :invalid_data, value: {invalid_data: true})
   end
 
   def test_class_call_method
     result = Double.call(number: 2)
 
-    assert_success_result(result, value: 4)
+    assert_success_result(result, value: { number: 4 })
 
     result = Double.call(number: 0)
 
-    assert_failure_result(result, value: 'number must be greater than 0', type: :error)
+    assert_failure_result(result, type: :error, value: { message: 'number must be greater than 0' })
   end
 
   class Foo < Micro::Case::Strict::Safe
@@ -97,13 +97,13 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
   def test_that_exceptions_generate_a_failure
     result_1 = Divide.new(a: 2, b: 0).call
 
-    assert_exception_result(result_1, value: ZeroDivisionError)
+    assert_exception_result(result_1, value: { exception: ZeroDivisionError })
 
     # ---
 
     result_2 = Divide.call(a: 2, b: 0)
 
-    assert_exception_result(result_2, value: ZeroDivisionError)
+    assert_exception_result(result_2, value: { exception: ZeroDivisionError })
   end
 
   def test_to_proc
@@ -116,6 +116,9 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
 
     values = results.map(&:value)
 
-    assert_equal([2, 4, 6, 8], values)
+    assert_equal(
+      [{number: 2}, {number: 4}, {number: 6}, {number: 8}],
+      values
+    )
   end
 end

--- a/test/micro/case/strict_test.rb
+++ b/test/micro/case/strict_test.rb
@@ -6,7 +6,7 @@ class Micro::Case::StrictTest < Minitest::Test
 
     def call!
       if a.is_a?(Numeric) && b.is_a?(Numeric)
-        Success(a * b)
+        Success(result: a * b)
       else
         Failure(:invalid_data)
       end
@@ -17,7 +17,7 @@ class Micro::Case::StrictTest < Minitest::Test
     attributes :number
 
     def call!
-      return Failure { 'number must be greater than 0' } if number <= 0
+      return Failure result: 'number must be greater than 0' if number <= 0
 
       Multiply.call(a: number, b: number)
     end
@@ -84,10 +84,10 @@ class Micro::Case::StrictTest < Minitest::Test
     attributes :a, :b
 
     def call!
-      return Success(a / b) if a.is_a?(Integer) && b.is_a?(Integer)
+      return Success(result: a / b) if a.is_a?(Integer) && b.is_a?(Integer)
       Failure(:not_an_integer)
     rescue => e
-      Failure(e)
+      Failure result: e
     end
   end
 

--- a/test/micro/case/with_inner_flow_test.rb
+++ b/test/micro/case/with_inner_flow_test.rb
@@ -5,7 +5,7 @@ class Micro::Case::WithInnerFlowTest < Minitest::Test
     attribute :text
 
     def call!
-      Success { { number: text.to_i } }
+      Success result: { number: text.to_i }
     end
   end
 
@@ -13,7 +13,7 @@ class Micro::Case::WithInnerFlowTest < Minitest::Test
     attribute :number
 
     def call!
-      Success { { text: number.to_s } }
+      Success result: { text: number.to_s }
     end
   end
 
@@ -25,7 +25,7 @@ class Micro::Case::WithInnerFlowTest < Minitest::Test
     attribute :number
 
     def call!
-      Success { { number: number * 2 } }
+      Success result: { number: number * 2 }
     end
   end
 

--- a/test/micro/case/with_validation/base_test.rb
+++ b/test/micro/case/with_validation/base_test.rb
@@ -10,7 +10,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a * b)
+          Success(result: {number: a * b})
         end
       end
 
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success(number.to_s)
+          Success result: number.to_s
         end
       end
 

--- a/test/micro/case/with_validation/base_test.rb
+++ b/test/micro/case/with_validation/base_test.rb
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success result: number.to_s
+          Success result: { string: number.to_s }
         end
       end
 
@@ -32,7 +32,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         flow = Micro::Cases.flow([Multiply, NumberToString])
 
-        assert_success_result(flow.call(a: 2, b: 2), value: '4')
+        assert_success_result(flow.call(a: 2, b: 2), value: { string: '4' })
       end
 
       def test_failure

--- a/test/micro/case/with_validation/classes_with_flows/all_steps_with_validation_test.rb
+++ b/test/micro/case/with_validation/classes_with_flows/all_steps_with_validation_test.rb
@@ -13,7 +13,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           def call!
             number = text.include?('.') ? text.to_f : text.to_i
 
-            Success { { number: number } }
+            Success result: { number: number }
           end
         end
 
@@ -23,7 +23,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, presence: true
 
           def call!
-            Success { { text: number.to_s } }
+            Success result: { text: number.to_s }
           end
         end
 
@@ -37,7 +37,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, kind: Integer
 
           def call!
-            Success { { number: number * 2 } }
+            Success result: { number: number * 2 }
           end
         end
 

--- a/test/micro/case/with_validation/classes_with_flows/first_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/classes_with_flows/first_step_with_validation_test.rb
@@ -13,7 +13,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           def call!
             number = text.include?('.') ? text.to_f : text.to_i
 
-            Success { { number: number } }
+            Success result: { number: number }
           end
         end
 
@@ -21,7 +21,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           attribute :number
 
           def call!
-            Success { { text: number.to_s } }
+            Success result: { text: number.to_s }
           end
         end
 
@@ -35,7 +35,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, kind: Integer
 
           def call!
-            Success { { number: number * 2 } }
+            Success result: { number: number * 2 }
           end
         end
 

--- a/test/micro/case/with_validation/classes_with_flows/last_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/classes_with_flows/last_step_with_validation_test.rb
@@ -11,7 +11,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           def call!
             number = text.include?('.') ? text.to_f : text.to_i
 
-            Success { { number: number } }
+            Success result: { number: number }
           end
         end
 
@@ -21,7 +21,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, presence: true
 
           def call!
-            Success { { text: number.to_s } }
+            Success result: { text: number.to_s }
           end
         end
 
@@ -35,7 +35,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, kind: Integer
 
           def call!
-            Success { { number: number * 2 } }
+            Success result: { number: number * 2 }
           end
         end
 

--- a/test/micro/case/with_validation/disable_auto_validation_test.rb
+++ b/test/micro/case/with_validation/disable_auto_validation_test.rb
@@ -12,7 +12,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a * b)
+          Success result: { number: a * b }
         end
       end
 
@@ -22,7 +22,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a + b)
+          Success result: { number: a + b }
         end
       end
 

--- a/test/micro/case/with_validation/safe/base_test.rb
+++ b/test/micro/case/with_validation/safe/base_test.rb
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success(result: number.to_s)
+          Success(result: { string: number.to_s })
         end
       end
 
@@ -32,7 +32,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         flow = Micro::Cases.flow([Multiply, NumberToString])
 
-        assert_success_result(flow.call(a: 2, b: 2), value: '4')
+        assert_success_result(flow.call(a: 2, b: 2), value: { string: '4' })
       end
 
       def test_failure

--- a/test/micro/case/with_validation/safe/base_test.rb
+++ b/test/micro/case/with_validation/safe/base_test.rb
@@ -10,7 +10,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a * b)
+          Success(result: { number: a * b })
         end
       end
 
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success(number.to_s)
+          Success(result: number.to_s)
         end
       end
 

--- a/test/micro/case/with_validation/safe/classes_with_flows/all_steps_with_validation_test.rb
+++ b/test/micro/case/with_validation/safe/classes_with_flows/all_steps_with_validation_test.rb
@@ -13,7 +13,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           def call!
             number = text.include?('.') ? text.to_f : text.to_i
 
-            Success { { number: number } }
+            Success result: { number: number }
           end
         end
 
@@ -23,7 +23,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, presence: true
 
           def call!
-            Success { { text: number.to_s } }
+            Success result: { text: number.to_s }
           end
         end
 
@@ -37,7 +37,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, numericality: { only_integer: true }
 
           def call!
-            Success { { number: number * 2 } }
+            Success result: { number: number * 2 }
           end
         end
 

--- a/test/micro/case/with_validation/safe/classes_with_flows/first_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/safe/classes_with_flows/first_step_with_validation_test.rb
@@ -12,8 +12,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
           def call!
             number = text.include?('.') ? text.to_f : text.to_i
-
-            Success { { number: number } }
+            Success result: { number: number }
           end
         end
 
@@ -21,7 +20,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           attribute :number
 
           def call!
-            Success { { text: number.to_s } }
+            Success result: { text: number.to_s }
           end
         end
 
@@ -35,7 +34,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, numericality: { only_integer: true }
 
           def call!
-            Success { { number: number * 2 } }
+            Success result: { number: number * 2 }
           end
         end
 

--- a/test/micro/case/with_validation/safe/classes_with_flows/last_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/safe/classes_with_flows/last_step_with_validation_test.rb
@@ -11,7 +11,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           def call!
             number = text.include?('.') ? text.to_f : text.to_i
 
-            Success { { number: number } }
+            Success result: { number: number }
           end
         end
 
@@ -21,7 +21,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, presence: true
 
           def call!
-            Success { { text: number.to_s } }
+            Success result: { text: number.to_s }
           end
         end
 
@@ -35,7 +35,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           validates :number, numericality: { only_integer: true }
 
           def call!
-            Success { { number: number * 2 } }
+            Success result: { number: number * 2 }
           end
         end
 

--- a/test/micro/case/with_validation/safe/disable_auto_validation_test.rb
+++ b/test/micro/case/with_validation/safe/disable_auto_validation_test.rb
@@ -12,7 +12,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a * b)
+          Success(result: { number: a * b })
         end
       end
 
@@ -22,7 +22,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a + b)
+          Success result: { number: a + b }
         end
       end
 

--- a/test/micro/case/with_validation/safe/disable_auto_validation_test.rb
+++ b/test/micro/case/with_validation/safe/disable_auto_validation_test.rb
@@ -35,7 +35,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         result2 = Multiply.call(a: 2, b: 'a')
 
-        assert_exception_result(result2, value: TypeError)
+        assert_exception_result(result2, value: { exception: TypeError })
       end
     end
   end

--- a/test/micro/case/with_validation/safe/strict_test.rb
+++ b/test/micro/case/with_validation/safe/strict_test.rb
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success result: number.to_s
+          Success result: { string: number.to_s }
         end
       end
 
@@ -32,7 +32,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         flow = Micro::Cases.flow([Multiply, NumberToString])
 
-        assert_success_result(flow.call(a: 2, b: 2), value: '4')
+        assert_success_result(flow.call(a: 2, b: 2), value: { string: '4' } )
       end
 
       def test_failure

--- a/test/micro/case/with_validation/safe/strict_test.rb
+++ b/test/micro/case/with_validation/safe/strict_test.rb
@@ -10,7 +10,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a * b)
+          Success result: { number: a * b }
         end
       end
 
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success(number.to_s)
+          Success result: number.to_s
         end
       end
 

--- a/test/micro/case/with_validation/strict_test.rb
+++ b/test/micro/case/with_validation/strict_test.rb
@@ -10,7 +10,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :a, :b, presence: true, numericality: true
 
         def call!
-          Success(number: a * b)
+          Success result: { number: a * b }
         end
       end
 
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success(number.to_s)
+          Success result: number.to_s
         end
       end
 

--- a/test/micro/case/with_validation/strict_test.rb
+++ b/test/micro/case/with_validation/strict_test.rb
@@ -19,7 +19,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
         validates :number, presence: true, numericality: true
 
         def call!
-          Success result: number.to_s
+          Success result: { string: number.to_s }
         end
       end
 
@@ -32,7 +32,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         flow = Micro::Cases.flow([Multiply, NumberToString])
 
-        assert_success_result(flow.call(a: 2, b: 2), value: '4')
+        assert_success_result(flow.call(a: 2, b: 2), value: { string: '4' })
       end
 
       def test_failure

--- a/test/micro/case/wrong_usage_test.rb
+++ b/test/micro/case/wrong_usage_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Micro::Case::WrongUsageTest < Minitest::Test
+  class WrongSuccessResult < Micro::Case
+    attributes :a, :b
+
+    def call!
+      Success result: a / b
+    rescue ZeroDivisionError => exception
+      Failure result: exception
+    end
+  end
+
+  def test_the_wrong_usage_error_by_set_an_invalid_success_result
+    assert_raises_with_message(
+      Micro::Case::Error::InvalidSuccessResult,
+      "Success(result: 2) must be a Hash or Symbol"
+    ) { WrongSuccessResult.call(a: 4, b: 2) }
+  end
+
+  class WrongFailureResult < Micro::Case
+    attributes :a, :b
+
+    def call!
+      Success result: { division: a / b }
+    rescue ZeroDivisionError => exception
+      Failure result: 0
+    end
+  end
+
+  def test_the_wrong_usage_error_by_set_an_invalid_failure_result
+    assert_raises_with_message(
+      Micro::Case::Error::InvalidFailureResult,
+      "Failure(result: 0) must be a Hash, Symbol or an Exception"
+    ) { WrongFailureResult.call(a: 4, b: 0) }
+  end
+end

--- a/test/micro/case_test.rb
+++ b/test/micro/case_test.rb
@@ -6,9 +6,9 @@ class Micro::CaseTest < Minitest::Test
 
     def call!
       if a.is_a?(Numeric) && b.is_a?(Numeric)
-        Success(a * b)
+        Success result: a * b
       else
-        Failure(:invalid_data) { [a, b]}
+        Failure :invalid_data, result: [a, b]
       end
     end
   end
@@ -17,7 +17,7 @@ class Micro::CaseTest < Minitest::Test
     attributes :number
 
     def call!
-      return Failure { 'number must be greater than 0' } if number <= 0
+      return Failure result: 'number must be greater than 0' if number <= 0
 
       Multiply.call(a: number, b: 2)
     end
@@ -123,10 +123,10 @@ class Micro::CaseTest < Minitest::Test
     attributes :a, :b
 
     def call!
-      return Success(a / b) if a.is_a?(Integer) && b.is_a?(Integer)
+      return Success(result: a / b) if a.is_a?(Integer) && b.is_a?(Integer)
       Failure(:not_an_integer)
     rescue => e
-      Failure(e)
+      Failure result: e
     end
   end
 

--- a/test/micro/cases/flow/blend_test.rb
+++ b/test/micro/cases/flow/blend_test.rb
@@ -56,7 +56,7 @@ class Micro::Cases::Flow::BlendTest < Minitest::Test
     EXAMPLES.map(&:flow).each do |flow|
       result = flow.call(numbers: %w[1 1 2 a 3 4])
 
-      assert_failure_result(result, value: 'numbers must contain only numeric types')
+      assert_failure_result(result, value: { message: 'numbers must contain only numeric types' })
     end
   end
 end

--- a/test/micro/cases/flow/collection_test.rb
+++ b/test/micro/cases/flow/collection_test.rb
@@ -64,7 +64,7 @@ class Micro::Cases::Flow::CollectionTest < Minitest::Test
     EXAMPLES.map(&:flow).each do |flow|
       result = flow.call(numbers: %w[1 1 2 a 3 4])
 
-      assert_failure_result(result, value: 'numbers must contain only numeric types')
+      assert_failure_result(result, value: { message: 'numbers must contain only numeric types' })
     end
   end
 end

--- a/test/micro/cases/flow/result_transitions_test.rb
+++ b/test/micro/cases/flow/result_transitions_test.rb
@@ -108,10 +108,10 @@ class Micro::Cases::Flow::ResultTransitionsTest < Minitest::Test
     # transitions[0][:success][:type]
     assert_equal(:ok, first_transition_result[:type])
 
-    # transitions[0][:success][:value]
-    assert_equal([:user], first_transition_result[:value].keys)
+    # transitions[0][:success][:result]
+    assert_equal([:user], first_transition_result[:result].keys)
 
-    assert_instance_of(User, first_transition_result[:value][:user])
+    assert_instance_of(User, first_transition_result[:result][:user])
 
     # transitions[0][:accessible_attributes]
     assert_equal([:email, :password, :description], first_transition[:accessible_attributes])
@@ -142,10 +142,10 @@ class Micro::Cases::Flow::ResultTransitionsTest < Minitest::Test
     # transitions[1][:success][:type]
     assert_equal(:ok, second_transition_result[:type])
 
-    # transitions[1][:success][:value]
-    assert_equal([:user], second_transition_result[:value].keys)
+    # transitions[1][:success][:result]
+    assert_equal([:user], second_transition_result[:result].keys)
 
-    assert_instance_of(User, second_transition_result[:value][:user])
+    assert_instance_of(User, second_transition_result[:result][:user])
 
     # transitions[1][:accessible_attributes]
     assert_equal([:email, :password, :description, :user], second_transition[:accessible_attributes])
@@ -178,13 +178,13 @@ class Micro::Cases::Flow::ResultTransitionsTest < Minitest::Test
     # transitions[2][:success][:type]
     assert_equal(:ok, third_transition_result[:type])
 
-    # transitions[2][:success][:value]
-    assert_equal([:todo], third_transition_result[:value].keys)
+    # transitions[2][:success][:result]
+    assert_equal([:todo], third_transition_result[:result].keys)
 
-    assert_instance_of(Todo, third_transition_result[:value][:todo])
+    assert_instance_of(Todo, third_transition_result[:result][:todo])
     assert_equal(
       third_transition_use_case[:attributes][:description],
-      third_transition_result[:value][:todo].description
+      third_transition_result[:result][:todo].description
     )
 
     # transitions[2][:accessible_attributes]

--- a/test/micro/cases/flow_test.rb
+++ b/test/micro/cases/flow_test.rb
@@ -48,11 +48,11 @@ class Micro::Cases::FlowTest < Minitest::Test
       # transitions[0][:success][:type]
       assert_equal(:ok, first_transition_result[:type])
 
-      # transitions[0][:success][:value]
-      assert_equal([:job], first_transition_result[:value].keys)
+      # transitions[0][:success][:result]
+      assert_equal([:job], first_transition_result[:result].keys)
 
-      assert_instance_of(Jobs::Entity, first_transition_result[:value][:job])
-      assert_equal('sleeping', first_transition_result[:value][:job].state)
+      assert_instance_of(Jobs::Entity, first_transition_result[:result][:job])
+      assert_equal('sleeping', first_transition_result[:result][:job].state)
 
       # transitions[0][:accessible_attributes]
       assert_equal([:job], first_transition[:accessible_attributes])
@@ -84,11 +84,11 @@ class Micro::Cases::FlowTest < Minitest::Test
       # transitions[1][:success][:type]
       assert_equal(:state_updated, second_transition_result[:type])
 
-      # transitions[1][:success][:value]
-      assert_equal([:job, :changes], second_transition_result[:value].keys)
+      # transitions[1][:success][:result]
+      assert_equal([:job, :changes], second_transition_result[:result].keys)
 
-      assert_instance_of(Jobs::Entity, second_transition_result[:value][:job])
-      assert_equal('running', second_transition_result[:value][:job].state)
+      assert_instance_of(Jobs::Entity, second_transition_result[:result][:job])
+      assert_equal('running', second_transition_result[:result][:job].state)
 
       # transitions[1][:accessible_attributes]
       assert_equal([:job], second_transition[:accessible_attributes])
@@ -122,11 +122,11 @@ class Micro::Cases::FlowTest < Minitest::Test
       # transitions[0][:success][:type]
       assert_equal(:ok, first_transition_result[:type])
 
-      # transitions[0][:success][:value]
-      assert_equal([:job], first_transition_result[:value].keys)
+      # transitions[0][:success][:result]
+      assert_equal([:job], first_transition_result[:result].keys)
 
-      assert_instance_of(Jobs::Entity, first_transition_result[:value][:job])
-      assert_equal('running', first_transition_result[:value][:job].state)
+      assert_instance_of(Jobs::Entity, first_transition_result[:result][:job])
+      assert_equal('running', first_transition_result[:result][:job].state)
 
       # transitions[0][:accessible_attributes]
       assert_equal([:job, :changes], first_transition[:accessible_attributes])
@@ -157,8 +157,8 @@ class Micro::Cases::FlowTest < Minitest::Test
       # transitions[1][:failure][:type]
       assert_equal(:invalid_state_transition, second_transition_result[:type])
 
-      # transitions[1][:failure][:value]
-      assert_equal({ invalid_state_transition: true }, second_transition_result[:value])
+      # transitions[1][:failure][:result]
+      assert_equal({ invalid_state_transition: true }, second_transition_result[:result])
 
       # transitions[1][:accessible_attributes]
       assert_equal([:job, :changes], second_transition[:accessible_attributes])

--- a/test/micro/cases/flow_test.rb
+++ b/test/micro/cases/flow_test.rb
@@ -17,7 +17,7 @@ class Micro::Cases::FlowTest < Minitest::Test
         .call(result1)
         .on_success { raise }
         .on_failure do |(value, _type)|
-          assert_equal(:invalid_state_transition, value)
+          assert_equal({ invalid_state_transition: true }, value)
         end
 
     result1.transitions.tap do |result_transitions|
@@ -158,7 +158,7 @@ class Micro::Cases::FlowTest < Minitest::Test
       assert_equal(:invalid_state_transition, second_transition_result[:type])
 
       # transitions[1][:failure][:value]
-      assert_equal(:invalid_state_transition, second_transition_result[:value])
+      assert_equal({ invalid_state_transition: true }, second_transition_result[:value])
 
       # transitions[1][:accessible_attributes]
       assert_equal([:job, :changes], second_transition[:accessible_attributes])
@@ -176,7 +176,7 @@ class Micro::Cases::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |(value, _type)| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, _type)| assert_equal({ invalid_state_transition: true }, value) }
   end
 
   def test_calling_with_a_use_case_instance
@@ -194,14 +194,14 @@ class Micro::Cases::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |data| assert_equal(:invalid_state_transition, data.value) }
+      .on_failure { |data| assert_equal({invalid_state_transition: true}, data.value) }
   end
 
   def test_calling_with_a_use_case_class
     Jobs::Run
       .call(Jobs::State::Default)
       .on_success { raise }
-      .on_failure(:invalid_uuid) { |job| assert_nil(job.id) }
+      .on_failure(:invalid_uuid) { |result| assert_nil(result[:job].id) }
       .on_failure(:invalid_uuid) do |_job, use_case|
         assert_instance_of(Jobs::ValidateID, use_case)
       end

--- a/test/micro/cases/safe/flow/blend_test.rb
+++ b/test/micro/cases/safe/flow/blend_test.rb
@@ -56,7 +56,7 @@ class Micro::Cases::Safe::Flow::BlendTest < Minitest::Test
     EXAMPLES.map(&:flow).each do |flow|
       result = flow.call(numbers: %w[1 1 2 a 3 4])
 
-      assert_failure_result(result, value: 'numbers must contain only numeric types')
+      assert_failure_result(result, value: { message: 'numbers must contain only numeric types' })
     end
   end
 
@@ -89,7 +89,7 @@ class Micro::Cases::Safe::Flow::BlendTest < Minitest::Test
       DoubleAllNumbersAndDivideByZero.call(numbers: %w[6 4 8]),
       SquareAllNumbersAndDivideByZero.call(numbers: %w[8 4 6])
     ].each do |result|
-      assert_exception_result(result, value: ZeroDivisionError)
+      assert_exception_result(result, value: { exception: ZeroDivisionError })
     end
   end
 
@@ -100,7 +100,7 @@ class Micro::Cases::Safe::Flow::BlendTest < Minitest::Test
   class Add < Micro::Case::Strict
     attributes :a, :b
 
-    def call!; Success(result: a + b); end
+    def call!; Success(result: { number: a + b }); end
   end
 
   def test_that_raises_wrong_usage_exceptions

--- a/test/micro/cases/safe/flow/blend_test.rb
+++ b/test/micro/cases/safe/flow/blend_test.rb
@@ -64,7 +64,7 @@ class Micro::Cases::Safe::Flow::BlendTest < Minitest::Test
     attributes :numbers
 
     def call!
-      Success(numbers: numbers.map { |number| number / 0 })
+      Success result: { numbers: numbers.map { |number| number / 0 } }
     end
   end
 
@@ -94,13 +94,13 @@ class Micro::Cases::Safe::Flow::BlendTest < Minitest::Test
   end
 
   class EmptyHash < Micro::Case
-    def call!; Success({}); end
+    def call!; Success(result: {}); end
   end
 
   class Add < Micro::Case::Strict
     attributes :a, :b
 
-    def call!; Success(a + b); end
+    def call!; Success(result: a + b); end
   end
 
   def test_that_raises_wrong_usage_exceptions

--- a/test/micro/cases/safe/flow/collection_test.rb
+++ b/test/micro/cases/safe/flow/collection_test.rb
@@ -65,7 +65,7 @@ class Micro::Cases::Safe::Flow::CollectionTest < Minitest::Test
     EXAMPLES.map(&:flow).each do |flow|
       result = flow.call(numbers: %w[1 1 2 a 3 4])
 
-      assert_failure_result(result, value: 'numbers must contain only numeric types')
+      assert_failure_result(result, value: { message: 'numbers must contain only numeric types' })
     end
   end
 end

--- a/test/micro/cases/safe/flow/result_transitions_test.rb
+++ b/test/micro/cases/safe/flow/result_transitions_test.rb
@@ -72,7 +72,7 @@ class Micro::Cases::Safe::Flow::ResultTransitionsTest < Minitest::Test
 
         return Failure(:validation_error) unless user.save
 
-        Success { { user: user } }
+        Success result: { user: user }
       end
     end
 
@@ -82,7 +82,7 @@ class Micro::Cases::Safe::Flow::ResultTransitionsTest < Minitest::Test
       def call!
         user = User.find_by_id(user_id)
 
-        return Success { { user: user } } if user
+        return Success result: { user: user } if user
 
         Failure(:user_not_found)
       end
@@ -95,7 +95,7 @@ class Micro::Cases::Safe::Flow::ResultTransitionsTest < Minitest::Test
         return Failure(:user_must_be_persisted) if user.new_record?
         return Failure(:wrong_password) if user.wrong_password?(password)
 
-        return Success { attributes(:user) }
+        return Success result: attributes(:user)
       end
     end
 
@@ -114,7 +114,7 @@ class Micro::Cases::Safe::Flow::ResultTransitionsTest < Minitest::Test
 
         return Failure(:validation_error) unless todo.save
 
-        Success { { todo: todo } }
+        Success result: { todo: todo }
       end
     end
 
@@ -124,7 +124,7 @@ class Micro::Cases::Safe::Flow::ResultTransitionsTest < Minitest::Test
       def call!
         todo = Todo.find_by_id_and_user_id(todo_id, user.id)
 
-        return Success { { todo: todo } } if todo
+        return Success result: { todo: todo } if todo
 
         Failure(:todo_not_found)
       end
@@ -139,7 +139,7 @@ class Micro::Cases::Safe::Flow::ResultTransitionsTest < Minitest::Test
           todo.save
         end
 
-        return Success { attributes(:todo) }
+        return Success result: attributes(:todo)
       end
     end
   end

--- a/test/micro/cases/safe/flow_test.rb
+++ b/test/micro/cases/safe/flow_test.rb
@@ -46,11 +46,11 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
       # transitions[0][:success][:type]
       assert_equal(:ok, first_transition_result[:type])
 
-      # transitions[0][:success][:value]
-      assert_equal([:job], first_transition_result[:value].keys)
+      # transitions[0][:success][:result]
+      assert_equal([:job], first_transition_result[:result].keys)
 
-      assert_instance_of(Jobs::Entity, first_transition_result[:value][:job])
-      assert_equal('sleeping', first_transition_result[:value][:job].state)
+      assert_instance_of(Jobs::Entity, first_transition_result[:result][:job])
+      assert_equal('sleeping', first_transition_result[:result][:job].state)
 
       # transitions[0][:accessible_attributes]
       assert_equal([:job], first_transition[:accessible_attributes])
@@ -82,11 +82,11 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
       # transitions[1][:success][:type]
       assert_equal(:state_updated, second_transition_result[:type])
 
-      # transitions[1][:success][:value]
-      assert_equal([:job, :changes], second_transition_result[:value].keys)
+      # transitions[1][:success][:result]
+      assert_equal([:job, :changes], second_transition_result[:result].keys)
 
-      assert_instance_of(Jobs::Entity, second_transition_result[:value][:job])
-      assert_equal('running', second_transition_result[:value][:job].state)
+      assert_instance_of(Jobs::Entity, second_transition_result[:result][:job])
+      assert_equal('running', second_transition_result[:result][:job].state)
 
       # transitions[1][:accessible_attributes]
       assert_equal([:job], second_transition[:accessible_attributes])
@@ -120,11 +120,11 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
       # transitions[0][:success][:type]
       assert_equal(:ok, first_transition_result[:type])
 
-      # transitions[0][:success][:value]
-      assert_equal([:job], first_transition_result[:value].keys)
+      # transitions[0][:success][:result]
+      assert_equal([:job], first_transition_result[:result].keys)
 
-      assert_instance_of(Jobs::Entity, first_transition_result[:value][:job])
-      assert_equal('running', first_transition_result[:value][:job].state)
+      assert_instance_of(Jobs::Entity, first_transition_result[:result][:job])
+      assert_equal('running', first_transition_result[:result][:job].state)
 
       # transitions[0][:accessible_attributes]
       assert_equal([:job, :changes], first_transition[:accessible_attributes])
@@ -155,8 +155,8 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
       # transitions[1][:failure][:type]
       assert_equal(:invalid_state_transition, second_transition_result[:type])
 
-      # transitions[1][:failure][:value]
-      assert_equal({ invalid_state_transition: true }, second_transition_result[:value])
+      # transitions[1][:failure][:result]
+      assert_equal({ invalid_state_transition: true }, second_transition_result[:result])
 
       # transitions[1][:accessible_attributes]
       assert_equal([:job, :changes], second_transition[:accessible_attributes])

--- a/test/micro/cases/safe/flow_test.rb
+++ b/test/micro/cases/safe/flow_test.rb
@@ -16,7 +16,7 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
       Jobs::Run
         .call(result1)
         .on_success { raise }
-        .on_failure { |(value, _type)| assert_equal(:invalid_state_transition, value) }
+        .on_failure { |(value, _type)| assert_equal({ invalid_state_transition: true }, value) }
 
     result1.transitions.tap do |result_transitions|
       assert_equal(2, result_transitions.size)
@@ -156,7 +156,7 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
       assert_equal(:invalid_state_transition, second_transition_result[:type])
 
       # transitions[1][:failure][:value]
-      assert_equal(:invalid_state_transition, second_transition_result[:value])
+      assert_equal({ invalid_state_transition: true }, second_transition_result[:value])
 
       # transitions[1][:accessible_attributes]
       assert_equal([:job, :changes], second_transition[:accessible_attributes])
@@ -174,7 +174,7 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |(value, *)| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, *)| assert_equal({ invalid_state_transition: true }, value) }
   end
 
   def test_calling_with_a_use_case_instance
@@ -192,14 +192,14 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
     Jobs::Run
       .call(result)
       .on_success { raise }
-      .on_failure { |(value, _type)| assert_equal(:invalid_state_transition, value) }
+      .on_failure { |(value, _type)| assert_equal({ invalid_state_transition: true }, value) }
   end
 
   def test_calling_with_a_use_case_class
     Jobs::Run
       .call(Jobs::State::Default)
       .on_success { raise }
-      .on_failure(:invalid_uuid) { |job| assert_nil(job.id) }
+      .on_failure(:invalid_uuid) { |result| assert_nil(result[:job].id) }
       .on_failure(:invalid_uuid) do |_job, use_case|
         assert_instance_of(Jobs::ValidateID, use_case)
       end

--- a/test/support/jobs/base.rb
+++ b/test/support/jobs/base.rb
@@ -45,7 +45,7 @@ module Jobs
     def call!
       return Success result: { job: job } if job.id =~ ACCEPTABLE_UUID
 
-      Failure :invalid_uuid, result: job
+      Failure :invalid_uuid, result: { job: job }
     end
   end
 

--- a/test/support/jobs/base.rb
+++ b/test/support/jobs/base.rb
@@ -14,7 +14,9 @@ module Jobs
   module State
     class Sleeping < Micro::Case
       def call!
-        Success(job: Entity.new(id: nil, state: 'sleeping'))
+        job = Entity.new(id: nil, state: 'sleeping')
+
+        Success result: { job: job }
       end
     end
 
@@ -27,9 +29,11 @@ module Jobs
     attributes :job
 
     def call!
-      return Success(job: job) if !job.id.nil?
+      return Success result: { job: job } if !job.id.nil?
 
-      Success(job: job.with_attribute(:id, SecureRandom.uuid))
+      new_job = job.with_attribute(:id, SecureRandom.uuid)
+
+      Success result: { job: new_job }
     end
   end
 
@@ -39,9 +43,9 @@ module Jobs
     attributes :job
 
     def call!
-      return Success(job: job) if job.id =~ ACCEPTABLE_UUID
+      return Success result: { job: job } if job.id =~ ACCEPTABLE_UUID
 
-      Failure(:invalid_uuid) { job }
+      Failure :invalid_uuid, result: job
     end
   end
 
@@ -53,9 +57,9 @@ module Jobs
 
       job_running = job.with_attribute(:state, 'running')
 
-      Success(:state_updated) do
-        {job: job_running, changes: job.diff_attributes(job_running) }
-      end
+      Success :state_updated, result: {
+        job: job_running, changes: job.diff_attributes(job_running)
+      }
     end
   end
 

--- a/test/support/jobs/safe.rb
+++ b/test/support/jobs/safe.rb
@@ -46,7 +46,7 @@ module Safe
       def call!
         return Success result: { job: job } if job.id =~ ACCEPTABLE_UUID
 
-        Failure :invalid_uuid, result: job
+        Failure :invalid_uuid, result: { job: job }
       end
     end
 

--- a/test/support/steps.rb
+++ b/test/support/steps.rb
@@ -8,7 +8,7 @@ module Steps
       if !numbers.nil? && numbers.all? { |value| String(value) =~ /\d+/ }
         Success result: { numbers: numbers.map(&:to_i) }
       else
-        Failure result: 'numbers must contain only numeric types'
+        Failure result: { message: 'numbers must contain only numeric types' }
       end
     end
   end

--- a/test/support/steps.rb
+++ b/test/support/steps.rb
@@ -6,9 +6,9 @@ module Steps
 
     def call!
       if !numbers.nil? && numbers.all? { |value| String(value) =~ /\d+/ }
-        Success(numbers: numbers.map(&:to_i))
+        Success result: { numbers: numbers.map(&:to_i) }
       else
-        Failure('numbers must contain only numeric types')
+        Failure result: 'numbers must contain only numeric types'
       end
     end
   end
@@ -17,7 +17,7 @@ module Steps
     attribute :numbers
 
     def call!
-      Success(numbers: numbers.map { |number| number + 2 })
+      Success result: { numbers: numbers.map { |number| number + 2 } }
     end
   end
 
@@ -25,7 +25,7 @@ module Steps
     attribute :numbers
 
     def call!
-      Success(numbers: numbers.map { |number| number * 2 })
+      Success result: { numbers: numbers.map { |number| number * 2 } }
     end
   end
 
@@ -33,7 +33,7 @@ module Steps
     attribute :numbers
 
     def call!
-      Success(numbers: numbers.map { |number| number * number })
+      Success result: { numbers: numbers.map { |number| number * number } }
     end
   end
 end

--- a/test/support/todoing/app/models/todos/create.rb
+++ b/test/support/todoing/app/models/todos/create.rb
@@ -9,7 +9,7 @@ module Todos
 
       return Failure(:validation_error) unless todo.save
 
-      Success { { todo: todo } }
+      Success result: { todo: todo }
     end
   end
 end

--- a/test/support/todoing/app/models/todos/find_with_user.rb
+++ b/test/support/todoing/app/models/todos/find_with_user.rb
@@ -7,7 +7,7 @@ module Todos
     def call!
       todo = Todo.find_by_id_and_user_id(todo_id, user.id)
 
-      return Success { { todo: todo } } if todo
+      return Success result: { todo: todo } if todo
 
       Failure(:todo_not_found)
     end

--- a/test/support/todoing/app/models/user_todo_list/mark_item_as_done.rb
+++ b/test/support/todoing/app/models/user_todo_list/mark_item_as_done.rb
@@ -5,8 +5,8 @@ module UserTodoList
     attribute :todo
 
     flow Users::Authenticate,
-         Todos::FindWithUser,
-         self.call!
+        Todos::FindWithUser,
+        self.call!
 
     def call!
       if todo.pending?
@@ -14,7 +14,7 @@ module UserTodoList
         todo.save
       end
 
-      return Success { attributes(:todo) }
+      Success result: attributes(:todo)
     end
   end
 end

--- a/test/support/todoing/app/models/users/create.rb
+++ b/test/support/todoing/app/models/users/create.rb
@@ -11,7 +11,7 @@ module Users
 
       return Failure(:validation_error) unless user.save
 
-      Success { { user: user } }
+      Success result: { user: user }
     end
   end
 end

--- a/test/support/todoing/app/models/users/find.rb
+++ b/test/support/todoing/app/models/users/find.rb
@@ -7,7 +7,7 @@ module Users
     def call!
       user = User.find_by_email(email)
 
-      return Success { { user: user } } if user
+      return Success result: { user: user } if user
 
       Failure(:user_not_found)
     end

--- a/test/support/todoing/app/models/users/validate_password.rb
+++ b/test/support/todoing/app/models/users/validate_password.rb
@@ -8,7 +8,7 @@ module Users
       return Failure(:user_must_be_persisted) if user.new_record?
       return Failure(:wrong_password) if user.wrong_password?(password)
 
-      return Success { attributes(:user) }
+      Success result: attributes(:user)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,7 +83,7 @@ module MicroCaseAssertions
   def assert_exception_result(result, value: :____skip____, type: :exception)
     assert_kind_of_result(result)
     assert_equal(type, result.type)
-    assert_kind_of(value, result.value) if value != :____skip____
+    assert_kind_of(value[:exception], result.value[:exception]) if value != :____skip____
     assert_predicate(result, :failure?)
 
     # assert the on_failure hook


### PR DESCRIPTION
- [x] **[Breaking change]** Add new rules to define a `Micro::Case` success or failure (Close: #23)
- [x] **[Breaking change]** Change Micro::Case::Result#transitions (Close: #27 )
- [x] Change the `Micro::Case::Result#then` behavior when it receives a block (Close: #28)
- [x] Make `Micro::Case::Result` quack like a Hash (Close: #20)
- [x] Update README