### PR TITLE
[3.0.0.rc4] Add a new feature: use cases with internal steps using its private methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ pry_version =
 group :development, :test do
   gem 'awesome_print', '~> 1.8'
 
+  gem 'byebug', '~> 10.0', '>= 10.0.2' if RUBY_VERSION =~ /\A2.2/
+
   gem 'pry', "~> #{pry_version}"
   gem 'pry-byebug', "~> #{pry_byebug_version}"
 end

--- a/README.md
+++ b/README.md
@@ -145,14 +145,6 @@ bad_result = Multiply.call(a: 2, b: '2')
 bad_result.failure? # true
 bad_result.data     # { message: "`a` and `b` attributes must be numeric" }
 
-#-----------------------------#
-# Calling a use case instance #
-#-----------------------------#
-
-result = Multiply.new(a: 2, b: 3).call
-
-result.value # { number: 6 }
-
 # Note:
 # ----
 # The result of a Micro::Case.call

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Version   | Documentation
     - [How to define custom result types?](#how-to-define-custom-result-types)
     - [Is it possible to define a custom result type without a block?](#is-it-possible-to-define-a-custom-result-type-without-a-block)
     - [How to use the result hooks?](#how-to-use-the-result-hooks)
-    - [Why the failure hook (without a type) exposes result itself?](#why-the-failure-hook-without-a-type-exposes-result-itself)
+    - [Why the hook usage without a type exposes the result itself?](#why-the-hook-usage-without-a-type-exposes-the-result-itself)
+      - [Using decomposition to access the result data and type](#using-decomposition-to-access-the-result-data-and-type)
     - [What happens if a result hook was declared multiple times?](#what-happens-if-a-result-hook-was-declared-multiple-times)
     - [How to use the `Micro::Case::Result#then` method?](#how-to-use-the-microcaseresultthen-method)
       - [What does happens when a `Micro::Case::Result#then` receives a block?](#what-does-happens-when-a-microcaseresultthen-receives-a-block)
@@ -352,7 +353,7 @@ Double
 # The use case responsible for the failure will be accessible as the second hook argument
 ```
 
-#### Why the failure hook (without a type) exposes result itself?
+#### Why the hook usage without a type exposes the result itself?
 
 Answer: To allow you to define how to handle the program flow using some
 conditional statement (like an `if`, `case/when`).
@@ -369,12 +370,8 @@ class Double < Micro::Case
   end
 end
 
-#=================================#
-# Using the result type and value #
-#=================================#
-
 Double
-  .call(-1)
+  .call(number: -1)
   .on_failure do |result, use_case|
     case result.type
     when :invalid then raise TypeError, "number must be a numeric value"
@@ -386,19 +383,20 @@ Double
 # The output will be the exception:
 #
 # ArgumentError (number `-1` must be greater than 0)
+```
 
-#=========================================================#
-# Using decomposition to access the result data and type #
-#=========================================================#
+> **Note:** The same that was did in the previous examples could be done with `#on_success` hook!
 
-# The syntax to decompose an Array can be used in methods, blocks and assigments.
-# If you doesn't know it, check out the Ruby doc:
-# https://ruby-doc.org/core-2.2.0/doc/syntax/assignment_rdoc.html#label-Array+Decomposition
-#
-# The object exposed in the hook failure is a Micro::Case::Result, and it can be decomposed using this syntax. e.g:
+##### Using decomposition to access the result data and type
+
+The syntax to decompose an Array can be used in methods, blocks and assigments.
+If you doesn't know it, check out the [Ruby doc](https://ruby-doc.org/core-2.2.0/doc/syntax/assignment_rdoc.html#label-Array+Decomposition).
+
+```ruby
+# The object exposed in the hook is a Micro::Case::Result, and it can be decomposed using this syntax. e.g:
 
 Double
-  .call(-2)
+  .call(number: -2)
   .on_failure do |(data, type), use_case|
     case type
     when :invalid then raise TypeError, 'number must be a numeric value'
@@ -411,6 +409,8 @@ Double
 #
 # ArgumentError (the number `-2` must be greater than 0)
 ```
+
+> **Note:** The same that was did in the previous examples could be done with `#on_success` hook!
 
 [⬆️ Back to Top](#table-of-contents-)
 
@@ -437,10 +437,11 @@ result[:number] * 4 # 24
 
 accum = 0
 
-result.on_success { |result| accum += result[:number] }
-      .on_success { |result| accum += result[:number] }
-      .on_success(:computed) { |result| accum += result[:number] }
-      .on_success(:computed) { |result| accum += result[:number] }
+result
+  .on_success { |result| accum += result[:number] }
+  .on_success { |result| accum += result[:number] }
+  .on_success(:computed) { |result| accum += result[:number] }
+  .on_success(:computed) { |result| accum += result[:number] }
 
 accum # 24
 
@@ -613,9 +614,9 @@ class DoubleAllNumbers < Micro::Case
        Steps::Double
 end
 
-DoubleAllNumbers
-  .call(numbers: %w[1 1 b 2 3 4])
-  .on_failure { |message| p message } # "numbers must contain only numeric types"
+DoubleAllNumbers.
+  call(numbers: %w[1 1 b 2 3 4]).
+  on_failure { |result| puts result[:message] } # "numbers must contain only numeric types"
 
 # Note:
 # ----
@@ -697,11 +698,11 @@ DoubleAllNumbersAndSquareAndAdd2 =
 
 SquareAllNumbersAndDouble
   .call(numbers: %w[1 1 2 2 3 4])
-  .on_success { |value| p value[:numbers] } # [6, 6, 12, 12, 22, 36]
+  .on_success { |result| p result[:numbers] } # [6, 6, 12, 12, 22, 36]
 
 DoubleAllNumbersAndSquareAndAdd2
   .call(numbers: %w[1 1 2 2 3 4])
-  .on_success { |value| p value[:numbers] } # [6, 6, 18, 18, 38, 66]
+  .on_success { |result| p result[:numbers] } # [6, 6, 18, 18, 38, 66]
 ```
 
 Note: You can blend any of the [available syntaxes/approaches](#how-to-create-a-flow-which-has-reusable-steps-to-define-a-complex-use-case) to create use case flows - [examples](https://github.com/serradura/u-case/blob/714c6b658fc6aa02617e6833ddee09eddc760f2a/test/micro/cases/flow/blend_test.rb#L5-L35).
@@ -948,8 +949,8 @@ result.type == :exception                   # true
 result.data                                 # { exception: #<ZeroDivisionError...> }
 result[:exception].is_a?(ZeroDivisionError) # true
 
-result.on_failure(:exception) do |exception|
-  AppLogger.error(exception.message) # E, [2019-08-21T00:05:44.195506 #9532] ERROR -- : divided by 0
+result.on_failure(:exception) do |result|
+  AppLogger.error(result[:exception].message) # E, [2019-08-21T00:05:44.195506 #9532] ERROR -- : divided by 0
 end
 
 # Note:
@@ -957,8 +958,8 @@ end
 # If you need to handle a specific error,
 # I recommend the usage of a case statement. e,g:
 
-result.on_failure(:exception) do |exception, use_case|
-  case exception
+result.on_failure(:exception) do |data, use_case|
+  case exception = data[:exception]
   when ZeroDivisionError then AppLogger.error(exception.message)
   else AppLogger.debug("#{use_case.class.name} was the use case responsible for the exception")
   end

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -201,8 +201,6 @@ module Micro
   end
 
   def self.case_or_flow?(arg)
-    return true if arg.is_a?(Class) && arg < Case
-    return true if arg.is_a?(Case) || arg.is_a?(Cases::Flow)
-    false
+    case?(arg) || arg.is_a?(Cases::Flow)
   end
 end

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -152,7 +152,7 @@ module Micro
 
         return result if result.is_a?(Result)
 
-        raise Error::UnexpectedResult.new(self.class)
+        raise Error::UnexpectedResult.new("#{self.class.name}#call!")
       end
 
       def __call_use_case_flow?

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -23,7 +23,11 @@ module Micro
     end
 
     def self.call(options = {})
-      new(options).call
+      new(options).__call__
+    end
+
+    class << self
+      alias __call__ call
     end
 
     def self.to_proc
@@ -60,7 +64,7 @@ module Micro
       input =
         arg.is_a?(Hash) ? result.__set_transitions_accessible_attributes__(arg) : arg
 
-      __new__(result, input).call
+      __new__(result, input).__call__
     end
 
     def self.__flow_builder
@@ -112,8 +116,8 @@ module Micro
       raise NotImplementedError
     end
 
-    def call
-      __call
+    def __call__
+      __call!
     end
 
     def __set_result__(result)
@@ -125,6 +129,10 @@ module Micro
 
     private
 
+      # This method was reserved for a new feature
+      def call
+      end
+
       def __setup_use_case(input)
         self.class.__flow_set!
 
@@ -133,7 +141,7 @@ module Micro
         self.attributes = input
       end
 
-      def __call
+      def __call!
         return __call_use_case_flow if __call_use_case_flow?
 
         __call_use_case
@@ -177,12 +185,12 @@ module Micro
         __get_result(false, value, type)
       end
 
-      def __result__
+      def __result
         @__result ||= Result.new
       end
 
       def __get_result(is_success, value, type)
-        __result__.__set__(is_success, value, type, self)
+        __result.__set__(is_success, value, type, self)
       end
 
       private_constant :MapFailureType

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -195,4 +195,14 @@ module Micro
 
       private_constant :MapFailureType
   end
+
+  def self.case?(arg)
+    (arg.is_a?(Class) && arg < Case) || arg.is_a?(Case)
+  end
+
+  def self.case_or_flow?(arg)
+    return true if arg.is_a?(Class) && arg < Case
+    return true if arg.is_a?(Case) || arg.is_a?(Cases::Flow)
+    false
+  end
 end

--- a/lib/micro/case/error.rb
+++ b/lib/micro/case/error.rb
@@ -4,9 +4,11 @@ module Micro
   class Case
     module Error
       class UnexpectedResult < TypeError
-        MESSAGE = '#call! must return an instance of Micro::Case::Result'.freeze
+        MESSAGE = 'must return an instance of Micro::Case::Result'.freeze
 
-        def initialize(klass); super(klass.name + MESSAGE); end
+        def initialize(context)
+          super("#{context} #{MESSAGE}")
+        end
       end
 
       class ResultIsAlreadyDefined < ArgumentError

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -11,7 +11,7 @@ module Micro
 
       attr_reader :type, :data, :use_case
 
-      alias_method :value, :data
+      alias value data
 
       def initialize
         @__transitions__ = []

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -79,7 +79,8 @@ module Micro
         else
           return yield_self if !use_case && can_yield_self
 
-          raise Error::InvalidInvocationOfTheThenMethod if !__is_a_use_case?(use_case)
+          # TODO: Test the then method with a Micro::Cases.{flow,safe_flow}() instance.
+          raise Error::InvalidInvocationOfTheThenMethod unless ::Micro.case_or_flow?(use_case)
 
           return self if failure?
 
@@ -102,7 +103,7 @@ module Micro
 
       def __set__(is_success, data, type, use_case)
         raise Error::InvalidResultType unless type.is_a?(Symbol)
-        raise Error::InvalidUseCase if !__is_a_use_case?(use_case)
+        raise Error::InvalidUseCase unless ::Micro.case?(use_case)
 
         @success, @type, @use_case = is_success, type, use_case
 
@@ -131,10 +132,6 @@ module Micro
 
         def __failure_type?(expected_type)
           failure? && (expected_type.nil? || expected_type == type)
-        end
-
-        def __is_a_use_case?(arg)
-          (arg.is_a?(Class) && arg < ::Micro::Case) || arg.is_a?(::Micro::Case)
         end
 
         def __update_transitions_accessible_attributes(attributes)

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -39,7 +39,7 @@ module Micro
       end
 
       def on_success(expected_type = nil)
-        return self unless success_type?(expected_type)
+        return self unless __success_type?(expected_type)
 
         hook_data = expected_type.nil? ? self : data
 
@@ -49,7 +49,7 @@ module Micro
       end
 
       def on_failure(expected_type = nil)
-        return self unless failure_type?(expected_type)
+        return self unless __failure_type?(expected_type)
 
         hook_data = expected_type.nil? ? self : data
 
@@ -59,7 +59,7 @@ module Micro
       end
 
       def on_exception(expected_exception = nil)
-        return self unless failure_type?(:exception)
+        return self unless __failure_type?(:exception)
 
         if !expected_exception || (Kind.is(Exception, expected_exception) && data.fetch(:exception).is_a?(expected_exception))
           yield(data, @use_case)
@@ -79,7 +79,7 @@ module Micro
         else
           return yield_self if !arg && can_yield_self
 
-          raise Error::InvalidInvocationOfTheThenMethod if !is_a_use_case?(arg)
+          raise Error::InvalidInvocationOfTheThenMethod if !__is_a_use_case?(arg)
 
           return self if failure?
 
@@ -102,7 +102,7 @@ module Micro
 
       def __set__(is_success, data, type, use_case)
         raise Error::InvalidResultType unless type.is_a?(Symbol)
-        raise Error::InvalidUseCase if !is_a_use_case?(use_case)
+        raise Error::InvalidUseCase if !__is_a_use_case?(use_case)
 
         @success, @type, @use_case = is_success, type, use_case
 
@@ -123,15 +123,15 @@ module Micro
 
       private
 
-        def success_type?(expected_type)
+        def __success_type?(expected_type)
           success? && (expected_type.nil? || expected_type == type)
         end
 
-        def failure_type?(expected_type)
+        def __failure_type?(expected_type)
           failure? && (expected_type.nil? || expected_type == type)
         end
 
-        def is_a_use_case?(arg)
+        def __is_a_use_case?(arg)
           (arg.is_a?(Class) && arg < ::Micro::Case) || arg.is_a?(::Micro::Case)
         end
 

--- a/lib/micro/case/safe.rb
+++ b/lib/micro/case/safe.rb
@@ -7,8 +7,8 @@ module Micro
         Cases::Safe::Flow
       end
 
-      def call
-        __call
+      def __call__
+        __call!
       rescue => exception
         raise exception if Error.by_wrong_usage?(exception)
 

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '3.0.0.rc3'.freeze
+    VERSION = '3.0.0.rc4'.freeze
   end
 end

--- a/lib/micro/case/with_activemodel_validation.rb
+++ b/lib/micro/case/with_activemodel_validation.rb
@@ -31,7 +31,7 @@ module Micro
 
         return result if result.is_a?(Result)
 
-        raise Error::UnexpectedResult.new(self.class)
+        raise Error::UnexpectedResult.new("#{self.class.name}#call!")
       end
 
       def failure_by_validation_error(object)

--- a/lib/micro/cases/flow.rb
+++ b/lib/micro/cases/flow.rb
@@ -51,12 +51,6 @@ module Micro
           arg.is_a?(Case::Result)
         end
 
-        def __arg_to_call?(arg)
-          return true if arg.is_a?(::Micro::Case) || arg.is_a?(Flow)
-          return true if arg.is_a?(Class) && arg < ::Micro::Case
-          return false
-        end
-
         def __call_arg(arg)
           output = arg.__call__
 
@@ -64,7 +58,7 @@ module Micro
         end
 
         def __first_use_case_input(arg)
-          return __call_arg(arg) if __arg_to_call?(arg)
+          return __call_arg(arg) if ::Micro.case_or_flow?(arg)
           return arg.value if __is_a_result?(arg)
 
           arg

--- a/lib/micro/cases/flow.rb
+++ b/lib/micro/cases/flow.rb
@@ -32,11 +32,11 @@ module Micro
       def call(arg = {})
         memo = arg.is_a?(Hash) ? arg.dup : {}
 
-        first_result = first_use_case_result(arg)
+        first_result = __first_use_case_result(arg)
 
         return first_result if @next_use_cases.empty?
 
-        next_use_cases_result(first_result, memo)
+        __next_use_cases_result(first_result, memo)
       end
 
       def to_proc
@@ -45,42 +45,42 @@ module Micro
 
       private
 
-        def is_a_result?(arg)
+        def __is_a_result?(arg)
           arg.is_a?(Case::Result)
         end
 
-        def arg_to_call?(arg)
+        def __arg_to_call?(arg)
           return true if arg.is_a?(::Micro::Case) || arg.is_a?(Flow)
           return true if arg.is_a?(Class) && arg < ::Micro::Case
           return false
         end
 
-        def call_arg(arg)
+        def __call_arg(arg)
           output = arg.call
 
-          is_a_result?(output) ? output.value : output
+          __is_a_result?(output) ? output.value : output
         end
 
-        def first_use_case_input(arg)
-          return call_arg(arg) if arg_to_call?(arg)
-          return arg.value if is_a_result?(arg)
+        def __first_use_case_input(arg)
+          return __call_arg(arg) if __arg_to_call?(arg)
+          return arg.value if __is_a_result?(arg)
 
           arg
         end
 
-        def first_use_case_result(arg)
-          input = first_use_case_input(arg)
+        def __first_use_case_result(arg)
+          input = __first_use_case_input(arg)
 
           result = Case::Result.new
 
           @first_use_case.__call_and_set_transition__(result, input)
         end
 
-        def next_use_case_result(use_case, result, input)
+        def __next_use_case_result(use_case, result, input)
           use_case.__new__(result, input).call
         end
 
-        def next_use_cases_result(first_result, memo)
+        def __next_use_cases_result(first_result, memo)
           @next_use_cases.reduce(first_result) do |result, use_case|
             break result if result.failure?
 
@@ -88,7 +88,7 @@ module Micro
 
             result.__set_transitions_accessible_attributes__(memo)
 
-            next_use_case_result(use_case, result, memo)
+            __next_use_case_result(use_case, result, memo)
           end
         end
     end

--- a/lib/micro/cases/flow.rb
+++ b/lib/micro/cases/flow.rb
@@ -39,6 +39,8 @@ module Micro
         __next_use_cases_result(first_result, memo)
       end
 
+      alias __call__ call
+
       def to_proc
         Proc.new { |arg| call(arg) }
       end
@@ -56,7 +58,7 @@ module Micro
         end
 
         def __call_arg(arg)
-          output = arg.call
+          output = arg.__call__
 
           __is_a_result?(output) ? output.value : output
         end
@@ -77,7 +79,7 @@ module Micro
         end
 
         def __next_use_case_result(use_case, result, input)
-          use_case.__new__(result, input).call
+          use_case.__new__(result, input).__call__
         end
 
         def __next_use_cases_result(first_result, memo)

--- a/lib/micro/cases/safe/flow.rb
+++ b/lib/micro/cases/safe/flow.rb
@@ -4,7 +4,7 @@ module Micro
   module Cases
     module Safe
       class Flow < Cases::Flow
-        private def next_use_case_result(use_case, result, input)
+        private def __next_use_case_result(use_case, result, input)
           instance = use_case.__new__(result, input)
           instance.call
         rescue => exception

--- a/lib/micro/cases/safe/flow.rb
+++ b/lib/micro/cases/safe/flow.rb
@@ -6,7 +6,7 @@ module Micro
       class Flow < Cases::Flow
         private def __next_use_case_result(use_case, result, input)
           instance = use_case.__new__(result, input)
-          instance.call
+          instance.__call__
         rescue => exception
           raise exception if Case::Error.by_wrong_usage?(exception)
 

--- a/test/micro/case/call_test.rb
+++ b/test/micro/case/call_test.rb
@@ -13,14 +13,11 @@ class Micro::Case::CallTest < Minitest::Test
   def test_the_calling_of_use_cases
     assert_raises(ArgumentError) { Steps::ConvertToNumbers.new() }
 
-    assert_instance_of(Failure, Steps::ConvertToNumbers.new({}).call)
     assert_instance_of(Failure, Steps::ConvertToNumbers.call({}))
     assert_instance_of(Failure, Steps::ConvertToNumbers.call)
   end
 
   def test_the_calling_of_collection_mapper_flows
-    assert_raises(NoMethodError) { Add2ToAllNumbers1.new({}).call }
-
     assert_instance_of(Failure, Add2ToAllNumbers1.call({}))
     assert_instance_of(Failure, Add2ToAllNumbers1.call)
   end

--- a/test/micro/case/result/steps_test.rb
+++ b/test/micro/case/result/steps_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class Micro::Case::Result::StepsTest < Minitest::Test
+  class ThirdSum < Micro::Case
+    attribute :second_sum
+
+    def call!
+      Success result: { third_sum: second_sum + 0.5 }
+    end
+  end
+
+  class DoSomeSumUsingThen1 < Micro::Case
+    attributes :a, :b
+
+    def call!
+      validate_attributes
+        .then(-> { sum_a_and_b })
+        .then(-> data { add(data, number: 3) })
+        .then(ThirdSum)
+    end
+
+    private
+
+      def validate_attributes
+        Kind.of?(Numeric, a, b) ? Success() : Failure()
+      end
+
+      def sum_a_and_b
+        Success result: { first_sum: a + b }
+      end
+
+      def add(data, number:)
+        Success result: { second_sum: data[:first_sum] + number }
+      end
+  end
+
+  def test_the_then_method_with_lambdas
+    resulta = DoSomeSumUsingThen1.call(a: 1, b: 2)
+
+    assert_success_result(resulta, value: { third_sum: 6.5 })
+
+    resultb = DoSomeSumUsingThen1.call(a: 1, b: '2')
+
+    assert_failure_result(resultb, value: { error: true })
+  end
+
+  class DoSomeSumUsingPipe1 < Micro::Case
+    attributes :a, :b
+
+    def call!
+      validate_attributes \
+        | -> { sum_a_and_b } \
+        | -> data { add(data, number: 4) } \
+        | ThirdSum
+    end
+
+    private
+
+      def validate_attributes
+        Kind.of?(Numeric, a, b) ? Success() : Failure()
+      end
+
+      def sum_a_and_b
+        Success result: { first_sum: a + b }
+      end
+
+      def add(data, number:)
+        Success result: { second_sum: data[:first_sum] + number }
+      end
+  end
+
+  def test_the_then_method_with_lambdas
+    resulta = DoSomeSumUsingPipe1.call(a: 1, b: 2)
+
+    assert_success_result(resulta, value: { third_sum: 7.5 })
+
+    resultb = DoSomeSumUsingPipe1.call(a: 1, b: '2')
+
+    assert_failure_result(resultb, value: { error: true })
+  end
+end

--- a/test/micro/case/result/steps_test.rb
+++ b/test/micro/case/result/steps_test.rb
@@ -2,10 +2,12 @@ require 'test_helper'
 
 class Micro::Case::Result::StepsTest < Minitest::Test
   class ThirdSum < Micro::Case
-    attribute :second_sum
+    attribute :sum
 
     def call!
-      Success result: { third_sum: second_sum + 0.5 }
+      Success :third_sum, result: {
+        sum: sum + 0.5
+      }
     end
   end
 
@@ -22,26 +24,65 @@ class Micro::Case::Result::StepsTest < Minitest::Test
     private
 
       def validate_attributes
-        Kind.of?(Numeric, a, b) ? Success() : Failure()
+        Kind.of?(Numeric, a, b) ? Success(:valid) : Failure()
       end
 
       def sum_a_and_b
-        Success result: { first_sum: a + b }
+        Success :first_sum, result: { sum: a + b }
       end
 
       def add(data, number:)
-        Success result: { second_sum: data[:first_sum] + number }
+        Success :second_sum, result: {
+          sum: data[:sum] + number
+        }
       end
   end
 
   def test_the_then_method_with_lambdas
     resulta = DoSomeSumUsingThen1.call(a: 1, b: 2)
 
-    assert_success_result(resulta, value: { third_sum: 6.5 })
+    assert_success_result(resulta, value: { sum: 6.5 })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingThen1, attributes: { a: 1, b: 2 } },
+        success: { type: :valid, result: { valid: true } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingThen1, attributes: { a: 1, b: 2 } },
+        success: { type: :first_sum, result: { sum: 3 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingThen1, attributes: { a: 1, b: 2 } },
+        success: { type: :second_sum, result: { sum: 6 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: ThirdSum, attributes: { sum: 6 } },
+        success: { type: :third_sum, result: { sum: 6.5 } },
+        accessible_attributes: [:a, :b, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resulta.transitions[index])
+    end
+
+    # ---
 
     resultb = DoSomeSumUsingThen1.call(a: 1, b: '2')
 
     assert_failure_result(resultb, value: { error: true })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingThen1, attributes: { a: 1, b: '2' } },
+        failure: { type: :error, result: { error: true } },
+        accessible_attributes: [:a, :b]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resultb.transitions[index])
+    end
   end
 
   class DoSomeSumUsingPipe1 < Micro::Case
@@ -57,25 +98,62 @@ class Micro::Case::Result::StepsTest < Minitest::Test
     private
 
       def validate_attributes
-        Kind.of?(Numeric, a, b) ? Success() : Failure()
+        Kind.of?(Numeric, a, b) ? Success(:valid) : Failure()
       end
 
       def sum_a_and_b
-        Success result: { first_sum: a + b }
+        Success :first_sum, result: { sum: a + b }
       end
 
       def add(data, number:)
-        Success result: { second_sum: data[:first_sum] + number }
+        Success :second_sum, result: { sum: data[:sum] + number }
       end
   end
 
-  def test_the_then_method_with_lambdas
+  def test_the_then_method_with_pipes
     resulta = DoSomeSumUsingPipe1.call(a: 1, b: 2)
 
-    assert_success_result(resulta, value: { third_sum: 7.5 })
+    assert_success_result(resulta, value: { sum: 7.5 })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingPipe1, attributes: { a: 1, b: 2 } },
+        success: { type: :valid, result: { valid: true } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingPipe1, attributes: { a: 1, b: 2 } },
+        success: { type: :first_sum, result: { sum: 3 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingPipe1, attributes: { a: 1, b: 2 } },
+        success: { type: :second_sum, result: { sum: 7 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: ThirdSum, attributes: { sum: 7 } },
+        success: { type: :third_sum, result: { sum: 7.5 } },
+        accessible_attributes: [:a, :b, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resulta.transitions[index])
+    end
+
+    # ---
 
     resultb = DoSomeSumUsingPipe1.call(a: 1, b: '2')
 
     assert_failure_result(resultb, value: { error: true })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingPipe1, attributes: { a: 1, b: '2' } },
+        failure: { type: :error, result: { error: true } },
+        accessible_attributes: [:a, :b]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resultb.transitions[index])
+    end
   end
 end

--- a/test/micro/case/safe/with_inner_flow_test.rb
+++ b/test/micro/case/safe/with_inner_flow_test.rb
@@ -38,17 +38,6 @@ class Micro::Case::Safe::WithInnerFlowTest < Minitest::Test
       [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
       Double.use_cases
     )
-
-    # ---
-
-    instance = Double.new(text: '5')
-
-    assert_success_result(instance.call, value: { text: '10' })
-
-    assert_equal(
-      [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-      instance.use_cases
-    )
   end
 
   begin

--- a/test/micro/case/safe_test.rb
+++ b/test/micro/case/safe_test.rb
@@ -13,18 +13,6 @@ class Micro::Case::SafeTest < Minitest::Test
     end
   end
 
-  def test_instance_call_method
-    result = Divide.new(a: 2, b: 2).call
-
-    assert_success_result(result, value: { number: 1 })
-
-    # ---
-
-    result = Divide.new(a: 2.0, b: 2).call
-
-    assert_failure_result(result, type: :not_an_integer, value: { not_an_integer: true })
-  end
-
   def test_class_call_method
     result = Divide.call(a: 4, b: 2)
 
@@ -42,10 +30,8 @@ class Micro::Case::SafeTest < Minitest::Test
 
   def test_template_method
     assert_raises(NotImplementedError) { Micro::Case::Safe.call }
-    assert_raises(NotImplementedError) { Micro::Case::Safe.new({}).call }
 
     assert_raises(NotImplementedError) { Foo.call }
-    assert_raises(NotImplementedError) { Foo.new({}).call }
   end
 
   class LoremIpsum < Micro::Case::Safe
@@ -61,20 +47,12 @@ class Micro::Case::SafeTest < Minitest::Test
       Micro::Case::Error::UnexpectedResult,
       /LoremIpsum#call! must return an instance of Micro::Case::Result/
     ) { LoremIpsum.call(text: 'lorem ipsum') }
-
-    assert_raises_with_message(
-      Micro::Case::Error::UnexpectedResult,
-      /LoremIpsum#call! must return an instance of Micro::Case::Result/
-    ) { LoremIpsum.new(text: 'ipsum indolor').call }
   end
 
   def test_that_exceptions_generate_a_failure
-    [
-      Divide.new(a: 2, b: 0).call,
-      Divide.call(a: 2, b: 0)
-    ].each do |result|
-      assert_exception_result(result, value: { exception: ZeroDivisionError })
-    end
+    result = Divide.call(a: 2, b: 0)
+
+    assert_exception_result(result, value: { exception: ZeroDivisionError })
   end
 
   class Divide2ByArgV1 < Micro::Case::Safe

--- a/test/micro/case/strict/safe_test.rb
+++ b/test/micro/case/strict/safe_test.rb
@@ -23,16 +23,6 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
     end
   end
 
-  def test_instance_call_method
-    result = Multiply.new(a: 2, b: 2).call
-
-    assert_success_result(result, value: { number: 4 })
-
-    result = Multiply.new(a: 1, b: '1').call
-
-    assert_failure_result(result, type: :invalid_data, value: {invalid_data: true})
-  end
-
   def test_class_call_method
     result = Double.call(number: 2)
 
@@ -48,10 +38,8 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
 
   def test_template_method
     assert_raises(NotImplementedError) { Micro::Case::Strict::Safe.call }
-    assert_raises(NotImplementedError) { Micro::Case::Strict::Safe.new({}).call }
 
     assert_raises(NotImplementedError) { Foo.call }
-    assert_raises(NotImplementedError) { Foo.new({}).call }
   end
 
   class LoremIpsum < Micro::Case::Strict::Safe
@@ -67,11 +55,6 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
       Micro::Case::Error::UnexpectedResult,
       /LoremIpsum#call! must return an instance of Micro::Case::Result/
     ) { LoremIpsum.call(text: 'lorem ipsum') }
-
-    assert_raises_with_message(
-      Micro::Case::Error::UnexpectedResult,
-      /LoremIpsum#call! must return an instance of Micro::Case::Result/
-    ) { LoremIpsum.new(text: 'ipsum indolor').call }
   end
 
   def test_keywords_validation
@@ -95,12 +78,6 @@ class Micro::Case::Strict::SafeTest < Minitest::Test
   end
 
   def test_that_exceptions_generate_a_failure
-    result_1 = Divide.new(a: 2, b: 0).call
-
-    assert_exception_result(result_1, value: { exception: ZeroDivisionError })
-
-    # ---
-
     result_2 = Divide.call(a: 2, b: 0)
 
     assert_exception_result(result_2, value: { exception: ZeroDivisionError })

--- a/test/micro/case/strict_test.rb
+++ b/test/micro/case/strict_test.rb
@@ -23,16 +23,6 @@ class Micro::Case::StrictTest < Minitest::Test
     end
   end
 
-  def test_instance_call_method
-    result = Multiply.new(a: 2, b: 2).call
-
-    assert_success_result(result, value: { number: 4 })
-
-    result = Multiply.new(a: 1, b: '1').call
-
-    assert_failure_result(result, type: :invalid_data, value: { invalid_data: true })
-  end
-
   def test_class_call_method
     result = Double.call(number: 2)
 
@@ -48,10 +38,8 @@ class Micro::Case::StrictTest < Minitest::Test
 
   def test_template_method
     assert_raises(NotImplementedError) { Micro::Case::Strict.call }
-    assert_raises(NotImplementedError) { Micro::Case::Strict.new({}).call }
 
     assert_raises(NotImplementedError) { Foo.call }
-    assert_raises(NotImplementedError) { Foo.new({}).call }
   end
 
   class LoremIpsum < Micro::Case::Strict
@@ -67,11 +55,6 @@ class Micro::Case::StrictTest < Minitest::Test
       Micro::Case::Error::UnexpectedResult,
       /LoremIpsum#call! must return an instance of Micro::Case::Result/
     ) { LoremIpsum.call(text: 'lorem ipsum') }
-
-    assert_raises_with_message(
-      Micro::Case::Error::UnexpectedResult,
-      /LoremIpsum#call! must return an instance of Micro::Case::Result/
-    ) { LoremIpsum.new(text: 'ipsum indolor').call }
   end
 
   def test_keywords_validation

--- a/test/micro/case/with_inner_flow_test.rb
+++ b/test/micro/case/with_inner_flow_test.rb
@@ -38,17 +38,6 @@ class Micro::Case::WithInnerFlowTest < Minitest::Test
       [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
       Double.use_cases
     )
-
-    # ---
-
-    instance = Double.new(text: '5')
-
-    assert_success_result(instance.call, value: { text: '10' })
-
-    assert_equal(
-      [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-      instance.use_cases
-    )
   end
 
   begin

--- a/test/micro/case/with_validation/base_test.rb
+++ b/test/micro/case/with_validation/base_test.rb
@@ -24,7 +24,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
       end
 
       def test_success
-        calculation = Multiply.new(a: 2, b: 2).call
+        calculation = Multiply.call(a: 2, b: 2)
 
         assert_success_result(calculation, value: { number: 4 })
 
@@ -36,14 +36,14 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
       end
 
       def test_failure
-        result = Multiply.new(a: 1, b: nil).call
+        result = Multiply.call(a: 1, b: nil)
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(["can't be blank", 'is not a number'], result.value[:errors][:b])
 
         # ---
 
-        result = Multiply.new(a: 1, b: 'a').call
+        result = Multiply.call(a: 1, b: 'a')
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(['is not a number'], result.value[:errors][:b])

--- a/test/micro/case/with_validation/classes_with_flows/all_steps_with_validation_test.rb
+++ b/test/micro/case/with_validation/classes_with_flows/all_steps_with_validation_test.rb
@@ -62,17 +62,6 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           assert_failure_result(result, type: :validation_error)
 
           assert_equal(['must be a kind of: Integer'], result.value[:errors][:number])
-
-          # ---
-
-          instance = Double.new(text: '5')
-
-          assert_success_result(instance.call, value: { text: '10' })
-
-          assert_equal(
-            [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-            instance.use_cases
-          )
         end
       end
     end

--- a/test/micro/case/with_validation/classes_with_flows/first_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/classes_with_flows/first_step_with_validation_test.rb
@@ -60,17 +60,6 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           assert_failure_result(result, type: :validation_error)
 
           assert_equal(['must be a kind of: Integer'], result.value[:errors][:number])
-
-          # ---
-
-          instance = Double.new(text: '5')
-
-          assert_success_result(instance.call, value: { text: '10' })
-
-          assert_equal(
-            [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-            instance.use_cases
-          )
         end
       end
     end

--- a/test/micro/case/with_validation/classes_with_flows/last_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/classes_with_flows/last_step_with_validation_test.rb
@@ -56,17 +56,6 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           assert_failure_result(result, type: :validation_error)
 
           assert_equal(['must be a kind of: Integer'], result.value[:errors][:number])
-
-          # ---
-
-          instance = Double.new(text: '5')
-
-          assert_success_result(instance.call, value: { text: '10' })
-
-          assert_equal(
-            [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-            instance.use_cases
-          )
         end
       end
     end

--- a/test/micro/case/with_validation/safe/base_test.rb
+++ b/test/micro/case/with_validation/safe/base_test.rb
@@ -24,7 +24,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
       end
 
       def test_success
-        calculation = Multiply.new(a: 2, b: 2).call
+        calculation = Multiply.call(a: 2, b: 2)
 
         assert_success_result(calculation, value: { number: 4 })
 
@@ -36,14 +36,14 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
       end
 
       def test_failure
-        result = Multiply.new(a: 1, b: nil).call
+        result = Multiply.call(a: 1, b: nil)
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(["can't be blank", 'is not a number'], result.value[:errors][:b])
 
         # ---
 
-        result = Multiply.new(a: 1, b: 'a').call
+        result = Multiply.call(a: 1, b: 'a')
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(['is not a number'], result.value[:errors][:b])

--- a/test/micro/case/with_validation/safe/classes_with_flows/all_steps_with_validation_test.rb
+++ b/test/micro/case/with_validation/safe/classes_with_flows/all_steps_with_validation_test.rb
@@ -62,17 +62,6 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           assert_failure_result(result, type: :validation_error)
 
           assert_equal(['must be an integer'], result.value[:errors][:number])
-
-          # ---
-
-          instance = Double.new(text: '5')
-
-          assert_success_result(instance.call, value: { text: '10' })
-
-          assert_equal(
-            [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-            instance.use_cases
-          )
         end
       end
     end

--- a/test/micro/case/with_validation/safe/classes_with_flows/first_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/safe/classes_with_flows/first_step_with_validation_test.rb
@@ -59,17 +59,6 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           assert_failure_result(result, type: :validation_error)
 
           assert_equal(['must be an integer'], result.value[:errors][:number])
-
-          # ---
-
-          instance = Double.new(text: '5')
-
-          assert_success_result(instance.call, value: { text: '10' })
-
-          assert_equal(
-            [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-            instance.use_cases
-          )
         end
       end
     end

--- a/test/micro/case/with_validation/safe/classes_with_flows/last_step_with_validation_test.rb
+++ b/test/micro/case/with_validation/safe/classes_with_flows/last_step_with_validation_test.rb
@@ -56,17 +56,6 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
           assert_failure_result(result, type: :validation_error)
 
           assert_equal(['must be an integer'], result.value[:errors][:number])
-
-          # ---
-
-          instance = Double.new(text: '5')
-
-          assert_success_result(instance.call, value: { text: '10' })
-
-          assert_equal(
-            [ConvertTextToNumber, Double::Flow_Step, ConvertNumberToText],
-            instance.use_cases
-          )
         end
       end
     end

--- a/test/micro/case/with_validation/safe/strict_test.rb
+++ b/test/micro/case/with_validation/safe/strict_test.rb
@@ -24,7 +24,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
       end
 
       def test_success
-        calculation = Multiply.new(a: 2, b: 2).call
+        calculation = Multiply.call(a: 2, b: 2)
 
         assert_success_result(calculation, value: { number: 4 })
 
@@ -42,14 +42,14 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         # ---
 
-        result = Multiply.new(a: 1, b: nil).call
+        result = Multiply.call(a: 1, b: nil)
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(["can't be blank", 'is not a number'], result.value[:errors][:b])
 
         # ---
 
-        result = Multiply.new(a: 1, b: 'a').call
+        result = Multiply.call(a: 1, b: 'a')
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(['is not a number'], result.value[:errors][:b])

--- a/test/micro/case/with_validation/strict_test.rb
+++ b/test/micro/case/with_validation/strict_test.rb
@@ -24,7 +24,7 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
       end
 
       def test_success
-        calculation = Multiply.new(a: 2, b: 2).call
+        calculation = Multiply.call(a: 2, b: 2)
 
         assert_success_result(calculation, value: { number: 4 })
 
@@ -42,14 +42,14 @@ if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') <= '6.0.0'
 
         # ---
 
-        result = Multiply.new(a: 1, b: nil).call
+        result = Multiply.call(a: 1, b: nil)
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(["can't be blank", 'is not a number'], result.value[:errors][:b])
 
         # ---
 
-        result = Multiply.new(a: 1, b: 'a').call
+        result = Multiply.call(a: 1, b: 'a')
 
         assert_failure_result(result, type: :validation_error)
         assert_equal(['is not a number'], result.value[:errors][:b])

--- a/test/micro/case_test.rb
+++ b/test/micro/case_test.rb
@@ -31,16 +31,6 @@ class Micro::CaseTest < Minitest::Test
     end
   end
 
-  def test_the_instance_call_method
-    result = Multiply.new(a: 2, b: 2).call
-
-    assert_success_result(result, value: { number: 4 })
-
-    result = Multiply.new(a: 1, b: '1').call
-
-    assert_failure_result(result, value: { attribute_values: [1, '1'] }, type: :invalid_data)
-  end
-
   def test_the_class_call_method
     result = Double.call(number: 3)
 
@@ -64,10 +54,8 @@ class Micro::CaseTest < Minitest::Test
 
   def test_the_template_method
     assert_raises(NotImplementedError) { Micro::Case.call }
-    assert_raises(NotImplementedError) { Micro::Case.new({}).call }
 
     assert_raises(NotImplementedError) { Foo.call }
-    assert_raises(NotImplementedError) { Foo.new({}).call }
   end
 
   class LoremIpsum < Micro::Case
@@ -83,11 +71,6 @@ class Micro::CaseTest < Minitest::Test
       Micro::Case::Error::UnexpectedResult,
       /LoremIpsum#call! must return an instance of Micro::Case::Result/
     ) { LoremIpsum.call(text: 'lorem ipsum') }
-
-    assert_raises_with_message(
-      Micro::Case::Error::UnexpectedResult,
-      /LoremIpsum#call! must return an instance of Micro::Case::Result/
-    ) { LoremIpsum.new(text: 'ipsum indolor').call }
   end
 
   def test_that_sets_a_result_object_avoiding_the_use_case_to_create_one
@@ -96,7 +79,7 @@ class Micro::CaseTest < Minitest::Test
     use_case = Multiply.new(a: 3, b: 2)
     use_case.__set_result__(result_instance)
 
-    result = use_case.call
+    result = use_case.__call__
 
     assert_same(result_instance, result)
   end
@@ -112,7 +95,7 @@ class Micro::CaseTest < Minitest::Test
 
   def test_when_already_exists_a_result_and_tries_to_set_a_new_one
     use_case = Multiply.new(a: 3, b: 2)
-    use_case.call
+    use_case.__call__
 
     assert_raises_with_message(ArgumentError, 'result is already defined') do
       use_case.__set_result__(Micro::Case::Result.new)


### PR DESCRIPTION
Closes #55 
Closes #54 

---

- [x] Normalize the name of all the private methods #55 
- [x] Remove Micro::Case#call (Breaking Change) #54
- [x] Add New feature (case with internal steps using its private methods)  
- Update README
  - [x] Remove examples which use `.new()` to instantiate a use case, enforce only one approach, the usage of the method `.call()`
   - [x] Change [Why the failure hook (without a type) exposes result itself?](https://github.com/serradura/u-case#why-the-failure-hook-without-a-type-exposes-result-itself) section, because now, the `on_success` has the same behavior of `on_failure` hook.
- [x] Bump version to 3.0.0.rc4

---

## New feature (case with internal steps using its private methods)  

![image](https://user-images.githubusercontent.com/305364/89111297-7e3f1600-d42a-11ea-960c-705f17234ebd.png)

### `Micro::Case::Result#transitions`

![Untitled-1_—_u-case](https://user-images.githubusercontent.com/305364/89121867-360b0c80-d499-11ea-807a-d2a678038fbf.png)

