### PR TITLE
[ISSUE-39] Micro::Cases.map()

### DIFF
--- a/lib/micro/cases.rb
+++ b/lib/micro/cases.rb
@@ -2,6 +2,7 @@
 
 require 'micro/cases/flow'
 require 'micro/cases/safe/flow'
+require 'micro/cases/map'
 
 module Micro
   module Cases
@@ -11,6 +12,10 @@ module Micro
 
     def self.safe_flow(args)
       Safe::Flow.build(args)
+    end
+
+    def self.map(args)
+      Map.build(args)
     end
   end
 end

--- a/lib/micro/cases/map.rb
+++ b/lib/micro/cases/map.rb
@@ -10,9 +10,9 @@ module Micro
       ValidArgs = -> (args) do
         Kind.of(Array, args).all? do |arg|
           if arg.is_a?(Array)
-            arg.size == 2 && Kind.is(::Micro::Case, arg.first) && arg.last.is_a?(Hash)
+            arg.size == 2 && Kind.is.Micro::Case(arg.first) && arg.last.is_a?(Hash)
           else
-            Kind.is(::Micro::Case, arg)
+            Kind.is.Micro::Case(arg)
           end
         end
       end

--- a/lib/micro/cases/map.rb
+++ b/lib/micro/cases/map.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Micro
+  module Cases
+    class Map
+      class InvalidUseCases < ArgumentError
+        def initialize; super('argument must be a collection of `Micro::Case` classes'.freeze); end
+      end
+
+      attr_reader :use_cases
+
+      def self.build(args)
+        use_cases = Kind.of.Array(args)
+
+        raise InvalidUseCases if use_cases.any? { |klass| !(klass < ::Micro::Case) }
+
+        new(use_cases)
+      end
+
+      def initialize(use_cases)
+        @use_cases = use_cases
+      end
+
+      def call(arg = {})
+        hash_arg = Kind.of.Hash(arg)
+        use_cases.map { |use_case| use_case.call(hash_arg) }
+      end
+    end
+  end
+end

--- a/test/micro/cases/map_test.rb
+++ b/test/micro/cases/map_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class Micro::Cases::MapTest < Minitest::Test
+  def test_the_data_array_validation_error_when_calling_the_build_method
+    [nil, 1, true, '', {}].each do |arg|
+      assert_raises_with_message(Kind::Error, "#{arg} expected to be a kind of Array") do
+        Micro::Cases::Map.build(arg)
+      end
+    end
+  end
+
+  class Foo < Micro::Case
+    attribute :foo
+
+    def call!
+      return Success(:filled_foo) if foo
+
+      Failure(:missing_foo)
+    end
+  end
+
+  class Bar < Micro::Case
+    attribute :bar
+
+    def call!
+      return Success(:filled_bar) if bar
+
+      Failure(:missing_bar)
+    end
+  end
+
+  class FooOrBar < Micro::Case
+    attributes :foo, :bar
+
+    def call!
+      return Success(:filled_foo_or_bar) if foo || bar
+
+      Failure(:missing_foo_and_bar)
+    end
+  end
+
+  class FooAndBar < Micro::Case
+    attributes :foo, :bar
+
+    def call!
+      return Success(:filled_foo_and_bar) if foo && bar
+
+      Failure(:missing_foo_or_bar)
+    end
+  end
+
+  def test_result_have_success_and_failure
+    results = Micro::Cases.map([Foo,
+                                Bar,
+                                FooOrBar,
+                                FooAndBar]).call(foo: 'foo')
+
+    assert_equal(results.select(&:success?).map { |result| result.use_case.class }, [Foo, FooOrBar])
+    assert_equal(results.select(&:failure?).map { |result| result.use_case.class }, [Bar, FooAndBar])
+  end
+
+  def test_build_succes_with_dependencies_injection
+    results = Micro::Cases.map([Foo,
+                                FooOrBar,
+                                [FooAndBar, bar: 'bar']]).call(foo: 'foo')
+
+    assert(results.all?(&:success?))
+  end
+end

--- a/test/micro/cases/map_test.rb
+++ b/test/micro/cases/map_test.rb
@@ -1,11 +1,23 @@
 require 'test_helper'
 
 class Micro::Cases::MapTest < Minitest::Test
-  def test_the_data_array_validation_error_when_calling_the_build_method
+  def test_invalid_types_should_raise_exception
     [nil, 1, true, '', {}].each do |arg|
       assert_raises_with_message(Kind::Error, "#{arg} expected to be a kind of Array") do
         Micro::Cases::Map.build(arg)
       end
+    end
+  end
+
+  def test_invalid_array_instances_should_raise_exception
+    assert_raises_with_message(Kind::Error, '"wrong" expected to be a kind of Module') do
+      Micro::Cases.map(%w[wrong params]).call(foo: 'foo')
+    end
+  end
+
+  def test_invalid_array_classes_should_raise_exception
+    assert_raises_with_message(Micro::Cases::Map::InvalidUseCases, 'argument must be a collection of `Micro::Case` classes') do
+      Micro::Cases.map([String, Integer]).call(foo: 'foo')
     end
   end
 


### PR DESCRIPTION
Solves issue #39, adding a method `.map` to Micro::Cases allowing the usage of the chain of responsibility pattern using the u-case.

### Tests
![image](https://user-images.githubusercontent.com/79534/90315966-f19a5a80-def5-11ea-9fe6-66a926c614fe.png)