### PR TITLE
New Micro::Case::Result methods to make it quack like a hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ A `Micro::Case::Result` stores the use cases output data. These are their main m
 - `#type` a Symbol which gives meaning for the result, this is useful to declare different types of failures or success.
 - `#data` the result data itself.
 - `#[]` and `#values_at` are shortcuts to access the `#data` values.
-- `#key?` returns `true` if the key is present `#data`.
+- `#key?` returns `true` if the key is present in `#data`.
 - `#value?` returns `true` if the given value is present in `#data`.
-- `#slice` returns a subhash of `#data` with only the given keys and their values.
+- `#slice` returns a new hash that includes only the given keys. If the given keys doesn't exist, a empty hash is returned.
 - `#on_success` or `#on_failure` are hook methods that help you to define the application flow.
 - `#then` this method will allow applying a new use case if the current result was a success. The idea of this feature is to allow the creation of dynamic flows.
 - `#transitions` returns an array with all of transformations wich a result [has during a flow](#how-to-understand-what-is-happening-during-a-flow-execution).

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ A `Micro::Case::Result` stores the use cases output data. These are their main m
 - `#type` a Symbol which gives meaning for the result, this is useful to declare different types of failures or success.
 - `#data` the result data itself.
 - `#[]` and `#values_at` are shortcuts to access the `#data` values.
+- `#key?` returns `true` if the key is present `#data`.
+- `#value?` returns `true` if the given value is present in `#data`.
+- `#slice` returns a subhash of `#data` with only the given keys and their values.
 - `#on_success` or `#on_failure` are hook methods that help you to define the application flow.
 - `#then` this method will allow applying a new use case if the current result was a success. The idea of this feature is to allow the creation of dynamic flows.
 - `#transitions` returns an array with all of transformations wich a result [has during a flow](#how-to-understand-what-is-happening-during-a-flow-execution).

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -30,6 +30,18 @@ module Micro
         data.values_at(*keys)
       end
 
+      def key?(key)
+        data.key?(key)
+      end
+
+      def value?(value)
+        data.value?(value)
+      end
+
+      def slice(*keys)
+        Utils.slice_hash(data, *keys)
+      end
+
       def success?
         @success
       end

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -39,7 +39,7 @@ module Micro
       end
 
       def slice(*keys)
-        Utils.slice_hash(data, *keys)
+        Utils.slice_hash(data, keys)
       end
 
       def success?

--- a/lib/micro/case/utils.rb
+++ b/lib/micro/case/utils.rb
@@ -14,6 +14,13 @@ module Micro
           end
         end
       end
+      def self.slice_hash(hash, *keys)
+        if Kind::Of::Hash(hash).respond_to?(:slice)
+          hash.slice(*keys)
+        else
+          hash.select { |key, _value| keys.include?(key) }
+        end
+      end
     end
   end
 end

--- a/lib/micro/case/utils.rb
+++ b/lib/micro/case/utils.rb
@@ -14,7 +14,7 @@ module Micro
           end
         end
       end
-      def self.slice_hash(hash, *keys)
+      def self.slice_hash(hash, keys)
         if Kind::Of::Hash(hash).respond_to?(:slice)
           hash.slice(*keys)
         else

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -60,6 +60,21 @@ class Micro::Case::ResultTest < Minitest::Test
 
     assert_equal([1], result.values_at(:a))
     assert_equal([2, 1], result.values_at(:b, :a))
+
+    # ---
+
+    assert_equal(true, result.key?(:a))
+    assert_equal(false, result.key?(:c))
+
+    # ---
+
+    assert_equal(true, result.value?(2))
+    assert_equal(false, result.value?(10))
+
+    # ---
+    
+    assert_equal({ a: 1, b: 2 }, result.slice(:a, :b, :c))
+    assert_equal({}, result.slice(:c))
   end
 
   def test_failure_result

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -63,13 +63,13 @@ class Micro::Case::ResultTest < Minitest::Test
 
     # ---
 
-    assert_equal(true, result.key?(:a))
-    assert_equal(false, result.key?(:c))
+    assert(result.key?(:a))
+    refute(result.key?(:c))
 
     # ---
 
-    assert_equal(true, result.value?(2))
-    assert_equal(false, result.value?(10))
+    assert(result.value?(2))
+    refute(result.value?(10))
 
     # ---
     


### PR DESCRIPTION
Solves issue #59, adding `#key?`, `#value?` and `#slice()` methods and their tests. Also updated the README.md with their description.