### PR TITLE
[3.0.0.rc6] Improve Micro::Case internal steps [NEW FEATURE]

### DIFF
--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -70,16 +70,11 @@ module Micro
     end
 
     def self.__new__(result, arg)
-      instance = new(arg)
+      input = result.__set_transitions_accessible_attributes__(arg)
+
+      instance = new(input)
       instance.__set_result__(result)
       instance
-    end
-
-    def self.__call_and_set_transition__(result, arg)
-      input =
-        arg.is_a?(Hash) ? result.__set_transitions_accessible_attributes__(arg) : arg
-
-      __new__(result, input).__call__
     end
 
     def self.__flow_builder__

--- a/lib/micro/case/config.rb
+++ b/lib/micro/case/config.rb
@@ -15,7 +15,7 @@ module Micro
 
       def enable_transitions=(value)
         Micro::Case::Result.class_variable_set(
-          :@@transition_tracking_disabled, !Kind::Of::Boolean(value)
+          :@@transition_tracking_enabled, Kind::Of::Boolean(value)
         )
       end
     end

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -157,7 +157,7 @@ module Micro
         def __call_proc(arg, expected)
           result = arg.arity.zero? ? arg.call : arg.call(data.clone)
 
-          return result if result.is_a?(Result)
+          return self if result === self
 
           raise Error::UnexpectedResult.new("#{Result.name}##{expected}")
         end
@@ -167,10 +167,10 @@ module Micro
             if arg.arity.zero?
               arg.call
             else
-              arg.call(attributes.is_a?(Hash) ? self.data.merge(attributes) : self.data)
+              arg.call(attributes.is_a?(Hash) ? data.merge(attributes) : data)
             end
 
-          return result if result.is_a?(Result)
+          return self if result === self
 
           raise Error::UnexpectedResult.new("#{use_case.class.name}#method(:#{arg.name})")
         end

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '3.0.0.rc5'.freeze
+    VERSION = '3.0.0.rc6'.freeze
   end
 end

--- a/lib/micro/cases/flow.rb
+++ b/lib/micro/cases/flow.rb
@@ -30,13 +30,11 @@ module Micro
       end
 
       def call!(input:, result:)
-        memo = input.is_a?(Hash) ? input.dup : Kind::Empty::HASH
-
-        first_result = @first_use_case.__call_and_set_transition__(result, input)
+        first_result = __next_use_case_result(@first_use_case, result, input)
 
         return first_result if @next_use_cases.empty?
 
-        __next_use_cases_result(first_result, memo)
+        __next_use_cases_result(first_result)
       end
 
       def call(input = Kind::Empty::HASH)
@@ -70,15 +68,11 @@ module Micro
           use_case.__new__(result, input).__call__
         end
 
-        def __next_use_cases_result(first_result, memo)
+        def __next_use_cases_result(first_result)
           @next_use_cases.reduce(first_result) do |result, use_case|
             break result if result.failure?
 
-            memo.merge!(result.value)
-
-            result.__set_transitions_accessible_attributes__(memo)
-
-            __next_use_case_result(use_case, result, memo)
+            __next_use_case_result(use_case, result, result.data)
           end
         end
     end

--- a/test/micro/case/internal_steps/with_lambdas_test.rb
+++ b/test/micro/case/internal_steps/with_lambdas_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Micro::Case::Result::StepsWithLambdasTest < Minitest::Test
+class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
   class ThirdSum < Micro::Case
     attribute :sum
 

--- a/test/micro/case/internal_steps/with_lambdas_test.rb
+++ b/test/micro/case/internal_steps/with_lambdas_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
-  class ThirdSum < Micro::Case
+  class SumHalf < Micro::Case
     attribute :sum
 
     def call!
@@ -18,7 +18,7 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
       validate_attributes
         .then(-> { sum_a_and_b })
         .then(-> data { add(data, number: 3) })
-        .then(ThirdSum)
+        .then(SumHalf)
     end
 
     private
@@ -52,17 +52,17 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
       {
         use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
         success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :valid]
       },
       {
         use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
         success: { type: :second_sum, result: { sum: 6 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :valid, :sum]
       },
       {
-        use_case: { class: ThirdSum, attributes: { sum: 6 } },
+        use_case: { class: SumHalf, attributes: { sum: 6 } },
         success: { type: :third_sum, result: { sum: 6.5 } },
-        accessible_attributes: [:a, :b, :sum]
+        accessible_attributes: [:a, :b, :valid, :sum]
       }
     ].each_with_index do |transition, index|
       assert_equal(transition, resulta.transitions[index])
@@ -119,7 +119,7 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
       validate_attributes \
         | -> { sum_a_and_b } \
         | -> data { add(data, number: 4) } \
-        | ThirdSum
+        | SumHalf
     end
 
     private
@@ -151,17 +151,17 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
       {
         use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
         success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :valid]
       },
       {
         use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
         success: { type: :second_sum, result: { sum: 7 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :valid, :sum]
       },
       {
-        use_case: { class: ThirdSum, attributes: { sum: 7 } },
+        use_case: { class: SumHalf, attributes: { sum: 7 } },
         success: { type: :third_sum, result: { sum: 7.5 } },
-        accessible_attributes: [:a, :b, :sum]
+        accessible_attributes: [:a, :b, :valid, :sum]
       }
     ].each_with_index do |transition, index|
       assert_equal(transition, resulta.transitions[index])
@@ -209,5 +209,137 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
       Micro::Case::Error::UnexpectedResult,
       /Micro::Case::Result#| -> {} must return an instance of Micro::Case::Result/
     ) { MultiplyByTwoUsingPipeWithLambdas.call(number: 2) }
+  end
+
+  class DoSomeCalcUsingThenWithLambdas < Micro::Case
+    attributes :a, :b
+
+    def call!
+      get_c
+        .then(-> { get_d })
+        .then(-> data { sum_a_b_c_d(data) })
+        .then(SumHalf)
+    end
+
+    private
+
+    def get_c
+      Success :c, result: { c: 3 }
+    end
+
+    def get_d
+      Success :d, result: { d: 4 }
+    end
+
+    def sum_a_b_c_d(data)
+      c, d = data.fetch(:c), data.fetch(:d)
+
+      Success :sum_a_b_c_d, result: { sum: a + b + c + d }
+    end
+  end
+
+  def test_the_data_accumulation_through_the_then_method
+    result = DoSomeCalcUsingThenWithLambdas.call(a: 1, b: 2)
+
+    assert_success_result(result, value: { sum: 10.5 })
+
+    [
+      {
+        use_case: {
+          class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2 }
+        },
+        success: {type: :c, result: { c: 3 }},
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2 }
+        },
+        success: { type: :d, result: { d: 4 }},
+        accessible_attributes: [:a, :b, :c]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2}
+        },
+        success: { type: :sum_a_b_c_d, result: { sum: 10 }},
+        accessible_attributes: [:a, :b, :c, :d]
+      },
+      {
+        use_case: {
+          class: SumHalf, attributes: { sum: 10 }
+        },
+        success: { type: :third_sum, result: { sum: 10.5 }},
+        accessible_attributes: [:a, :b, :c, :d, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, result.transitions[index])
+    end
+  end
+
+  class DoSomeCalcUsingPipeWithLambdas < Micro::Case
+    attributes :a, :b
+
+    def call!
+      get_c \
+        |-> { get_d } \
+        |-> data { sum_a_b_c_d(data) } \
+        | SumHalf
+    end
+
+    private
+
+    def get_c
+      Success :c, result: { c: 3 }
+    end
+
+    def get_d
+      Success :d, result: { d: 4 }
+    end
+
+    def sum_a_b_c_d(data)
+      c, d = data.fetch(:c), data.fetch(:d)
+
+      Success :sum_a_b_c_d, result: { sum: a + b + c + d }
+    end
+  end
+
+  def test_the_data_accumulation_through_the_pipe_method
+    result = DoSomeCalcUsingPipeWithLambdas.call(a: 2, b: 2)
+
+    assert_success_result(result, value: { sum: 11.5 })
+
+    [
+      {
+        use_case: {
+          class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2 }
+        },
+        success: {type: :c, result: { c: 3 }},
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2 }
+        },
+        success: { type: :d, result: { d: 4 }},
+        accessible_attributes: [:a, :b, :c]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2}
+        },
+        success: { type: :sum_a_b_c_d, result: { sum: 11 }},
+        accessible_attributes: [:a, :b, :c, :d]
+      },
+      {
+        use_case: {
+          class: SumHalf, attributes: { sum: 11 }
+        },
+        success: { type: :third_sum, result: { sum: 11.5 }},
+        accessible_attributes: [:a, :b, :c, :d, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, result.transitions[index])
+    end
   end
 end

--- a/test/micro/case/internal_steps/with_methods_test.rb
+++ b/test/micro/case/internal_steps/with_methods_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
-  class ThirdSum < Micro::Case
+  class SumHalf < Micro::Case
     attribute :sum
 
     def call!
@@ -18,7 +18,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
       validate_attributes
         .then(method(:sum_a_and_b))
         .then(method(:add), number: 3)
-        .then(ThirdSum)
+        .then(SumHalf)
     end
 
     private
@@ -52,17 +52,17 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
       {
         use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
         success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :valid]
       },
       {
         use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
         success: { type: :second_sum, result: { sum: 6 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :valid, :number, :sum]
       },
       {
-        use_case: { class: ThirdSum, attributes: { sum: 6 } },
+        use_case: { class: SumHalf, attributes: { sum: 6 } },
         success: { type: :third_sum, result: { sum: 6.5 } },
-        accessible_attributes: [:a, :b, :sum]
+        accessible_attributes: [:a, :b, :valid, :number, :sum]
       }
     ].each_with_index do |transition, index|
       assert_equal(transition, resulta.transitions[index])
@@ -123,7 +123,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
       validate_attributes \
         | method(:sum_a_and_b) \
         | method(:add) \
-        | ThirdSum
+        | SumHalf
     end
 
     private
@@ -155,17 +155,17 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
       {
         use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
         success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b, :number]
+        accessible_attributes: [:a, :b, :number, :valid]
       },
       {
         use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
         success: { type: :second_sum, result: { sum: 7 } },
-        accessible_attributes: [:a, :b, :number]
+        accessible_attributes: [:a, :b, :number, :valid, :sum]
       },
       {
-        use_case: { class: ThirdSum, attributes: { sum: 7 } },
+        use_case: { class: SumHalf, attributes: { sum: 7 } },
         success: { type: :third_sum, result: { sum: 7.5 } },
-        accessible_attributes: [:a, :b, :number, :sum]
+        accessible_attributes: [:a, :b, :number, :valid, :sum]
       }
     ].each_with_index do |transition, index|
       assert_equal(transition, resulta.transitions[index])
@@ -217,5 +217,137 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
       Micro::Case::Error::UnexpectedResult,
       /MultiplyByTwoUsingPipeWithMethods#method\(:normalize_number\) must return an instance of Micro::Case::Result/
     ) { MultiplyByTwoUsingPipeWithMethods.call(number: 2) }
+  end
+
+  class DoSomeCalcUsingThenWithMethods < Micro::Case
+    attributes :a, :b
+
+    def call!
+      get_c
+        .then(method(:get_d))
+        .then(method(:sum_a_b_c_d))
+        .then(SumHalf)
+    end
+
+    private
+
+    def get_c
+      Success :c, result: { c: 3 }
+    end
+
+    def get_d
+      Success :d, result: { d: 4 }
+    end
+
+    def sum_a_b_c_d(data)
+      c, d = data.fetch(:c), data.fetch(:d)
+
+      Success :sum_a_b_c_d, result: { sum: a + b + c + d }
+    end
+  end
+
+  def test_the_data_accumulation_through_the_then_method
+    result = DoSomeCalcUsingThenWithMethods.call(a: 1, b: 2)
+
+    assert_success_result(result, value: { sum: 10.5 })
+
+    [
+      {
+        use_case: {
+          class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+        },
+        success: {type: :c, result: { c: 3 }},
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+        },
+        success: { type: :d, result: { d: 4 }},
+        accessible_attributes: [:a, :b, :c]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2}
+        },
+        success: { type: :sum_a_b_c_d, result: { sum: 10 }},
+        accessible_attributes: [:a, :b, :c, :d]
+      },
+      {
+        use_case: {
+          class: SumHalf, attributes: { sum: 10 }
+        },
+        success: { type: :third_sum, result: { sum: 10.5 }},
+        accessible_attributes: [:a, :b, :c, :d, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, result.transitions[index])
+    end
+  end
+
+  class DoSomeCalcUsingPipeWithMethods < Micro::Case
+    attributes :a, :b
+
+    def call!
+      get_c \
+        | method(:get_d) \
+        | method(:sum_a_b_c_d) \
+        | SumHalf
+    end
+
+    private
+
+    def get_c
+      Success :c, result: { c: 3 }
+    end
+
+    def get_d
+      Success :d, result: { d: 4 }
+    end
+
+    def sum_a_b_c_d(data)
+      c, d = data.fetch(:c), data.fetch(:d)
+
+      Success :sum_a_b_c_d, result: { sum: a + b + c + d }
+    end
+  end
+
+  def test_the_data_accumulation_through_the_pipe_method
+    result = DoSomeCalcUsingPipeWithMethods.call(a: 2, b: 2)
+
+    assert_success_result(result, value: { sum: 11.5 })
+
+    [
+      {
+        use_case: {
+          class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+        },
+        success: {type: :c, result: { c: 3 }},
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+        },
+        success: { type: :d, result: { d: 4 }},
+        accessible_attributes: [:a, :b, :c]
+      },
+      {
+        use_case: {
+          class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2}
+        },
+        success: { type: :sum_a_b_c_d, result: { sum: 11 }},
+        accessible_attributes: [:a, :b, :c, :d]
+      },
+      {
+        use_case: {
+          class: SumHalf, attributes: { sum: 11 }
+        },
+        success: { type: :third_sum, result: { sum: 11.5 }},
+        accessible_attributes: [:a, :b, :c, :d, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, result.transitions[index])
+    end
   end
 end

--- a/test/micro/case/internal_steps/with_methods_test.rb
+++ b/test/micro/case/internal_steps/with_methods_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Micro::Case::Result::StepsWithMethodsTest < Minitest::Test
+class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
   class ThirdSum < Micro::Case
     attribute :sum
 

--- a/test/micro/case/result/steps/with_lambdas_test.rb
+++ b/test/micro/case/result/steps/with_lambdas_test.rb
@@ -1,0 +1,213 @@
+require 'test_helper'
+
+class Micro::Case::Result::StepsWithLambdasTest < Minitest::Test
+  class ThirdSum < Micro::Case
+    attribute :sum
+
+    def call!
+      Success :third_sum, result: {
+        sum: sum + 0.5
+      }
+    end
+  end
+
+  class DoSomeSumUsingThenWithLambdas < Micro::Case
+    attributes :a, :b
+
+    def call!
+      validate_attributes
+        .then(-> { sum_a_and_b })
+        .then(-> data { add(data, number: 3) })
+        .then(ThirdSum)
+    end
+
+    private
+
+      def validate_attributes
+        Kind.of?(Numeric, a, b) ? Success(:valid) : Failure()
+      end
+
+      def sum_a_and_b
+        Success :first_sum, result: { sum: a + b }
+      end
+
+      def add(data, number:)
+        Success :second_sum, result: {
+          sum: data[:sum] + number
+        }
+      end
+  end
+
+  def test_the_then_method_with_lambdas
+    resulta = DoSomeSumUsingThenWithLambdas.call(a: 1, b: 2)
+
+    assert_success_result(resulta, value: { sum: 6.5 })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
+        success: { type: :valid, result: { valid: true } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
+        success: { type: :first_sum, result: { sum: 3 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
+        success: { type: :second_sum, result: { sum: 6 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: ThirdSum, attributes: { sum: 6 } },
+        success: { type: :third_sum, result: { sum: 6.5 } },
+        accessible_attributes: [:a, :b, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resulta.transitions[index])
+    end
+
+    # ---
+
+    resultb = DoSomeSumUsingThenWithLambdas.call(a: 1, b: '2')
+
+    assert_failure_result(resultb, value: { error: true })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: '2' } },
+        failure: { type: :error, result: { error: true } },
+        accessible_attributes: [:a, :b]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resultb.transitions[index])
+    end
+  end
+
+  class MultiplyByTwoUsingThenWithLambdas < Micro::Case
+    attributes :number
+
+    def call!
+      validate_number
+        .then(-> { number.to_f })
+        .then(-> data { multiply_by_two(data[:number]) })
+    end
+
+    private
+
+    def validate_number
+      Kind.of?(Numeric, number) ? Success(:valid) : Failure()
+    end
+
+    def multiply_by_two(number)
+      Success(result: { number: number * 2 })
+    end
+  end
+
+  def test_the_then_method_error_when_a_lambda_doesnt_return_a_result
+    assert_raises_with_message(
+      Micro::Case::Error::UnexpectedResult,
+      /Micro::Case::Result#then\(-> {}\) must return an instance of Micro::Case::Result/
+    ) { MultiplyByTwoUsingThenWithLambdas.call(number: 2) }
+  end
+
+  class DoSomeSumUsingPipeWithLambdas < Micro::Case
+    attributes :a, :b
+
+    def call!
+      validate_attributes \
+        | -> { sum_a_and_b } \
+        | -> data { add(data, number: 4) } \
+        | ThirdSum
+    end
+
+    private
+
+      def validate_attributes
+        Kind.of?(Numeric, a, b) ? Success(:valid) : Failure()
+      end
+
+      def sum_a_and_b
+        Success :first_sum, result: { sum: a + b }
+      end
+
+      def add(data, number:)
+        Success :second_sum, result: { sum: data[:sum] + number }
+      end
+  end
+
+  def test_the_pipe_method_with_lambdas
+    resulta = DoSomeSumUsingPipeWithLambdas.call(a: 1, b: 2)
+
+    assert_success_result(resulta, value: { sum: 7.5 })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
+        success: { type: :valid, result: { valid: true } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
+        success: { type: :first_sum, result: { sum: 3 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
+        success: { type: :second_sum, result: { sum: 7 } },
+        accessible_attributes: [:a, :b]
+      },
+      {
+        use_case: { class: ThirdSum, attributes: { sum: 7 } },
+        success: { type: :third_sum, result: { sum: 7.5 } },
+        accessible_attributes: [:a, :b, :sum]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resulta.transitions[index])
+    end
+
+    # ---
+
+    resultb = DoSomeSumUsingPipeWithLambdas.call(a: 1, b: '2')
+
+    assert_failure_result(resultb, value: { error: true })
+
+    [
+      {
+        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: '2' } },
+        failure: { type: :error, result: { error: true } },
+        accessible_attributes: [:a, :b]
+      }
+    ].each_with_index do |transition, index|
+      assert_equal(transition, resultb.transitions[index])
+    end
+  end
+
+  class MultiplyByTwoUsingPipeWithLambdas < Micro::Case
+    attributes :number
+
+    def call!
+      validate_number \
+        | -> { number.to_f } \
+        | -> data { multiply_by_two(data[:number]) }
+    end
+
+    private
+
+    def validate_number
+      Kind.of?(Numeric, number) ? Success(:valid) : Failure()
+    end
+
+    def multiply_by_two(number)
+      Success(result: { number: number * 2 })
+    end
+  end
+
+  def test_the_pipe_method_error_when_a_lambda_doesnt_return_a_result
+    assert_raises_with_message(
+      Micro::Case::Error::UnexpectedResult,
+      /Micro::Case::Result#| -> {} must return an instance of Micro::Case::Result/
+    ) { MultiplyByTwoUsingPipeWithLambdas.call(number: 2) }
+  end
+end

--- a/test/micro/case/result/steps/with_methods_test.rb
+++ b/test/micro/case/result/steps/with_methods_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Micro::Case::Result::StepsTest < Minitest::Test
+class Micro::Case::Result::StepsWithMethodsTest < Minitest::Test
   class ThirdSum < Micro::Case
     attribute :sum
 
@@ -11,13 +11,13 @@ class Micro::Case::Result::StepsTest < Minitest::Test
     end
   end
 
-  class DoSomeSumUsingThen < Micro::Case
+  class DoSomeSumUsingThenWithMethods < Micro::Case
     attributes :a, :b
 
     def call!
       validate_attributes
-        .then(-> { sum_a_and_b })
-        .then(-> data { add(data, number: 3) })
+        .then(method(:sum_a_and_b))
+        .then(method(:add), number: 3)
         .then(ThirdSum)
     end
 
@@ -31,31 +31,31 @@ class Micro::Case::Result::StepsTest < Minitest::Test
         Success :first_sum, result: { sum: a + b }
       end
 
-      def add(data, number:)
+      def add(data)
         Success :second_sum, result: {
-          sum: data[:sum] + number
+          sum: data[:sum] + data[:number]
         }
       end
   end
 
-  def test_the_then_method_with_lambdas
-    resulta = DoSomeSumUsingThen.call(a: 1, b: 2)
+  def test_the_then_method_with_method_instances
+    resulta = DoSomeSumUsingThenWithMethods.call(a: 1, b: 2)
 
     assert_success_result(resulta, value: { sum: 6.5 })
 
     [
       {
-        use_case: { class: DoSomeSumUsingThen, attributes: { a: 1, b: 2 } },
+        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
         success: { type: :valid, result: { valid: true } },
         accessible_attributes: [:a, :b]
       },
       {
-        use_case: { class: DoSomeSumUsingThen, attributes: { a: 1, b: 2 } },
+        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
         success: { type: :first_sum, result: { sum: 3 } },
         accessible_attributes: [:a, :b]
       },
       {
-        use_case: { class: DoSomeSumUsingThen, attributes: { a: 1, b: 2 } },
+        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
         success: { type: :second_sum, result: { sum: 6 } },
         accessible_attributes: [:a, :b]
       },
@@ -70,13 +70,13 @@ class Micro::Case::Result::StepsTest < Minitest::Test
 
     # ---
 
-    resultb = DoSomeSumUsingThen.call(a: 1, b: '2')
+    resultb = DoSomeSumUsingThenWithMethods.call(a: 1, b: '2')
 
     assert_failure_result(resultb, value: { error: true })
 
     [
       {
-        use_case: { class: DoSomeSumUsingThen, attributes: { a: 1, b: '2' } },
+        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: '2' } },
         failure: { type: :error, result: { error: true } },
         accessible_attributes: [:a, :b]
       }
@@ -85,13 +85,13 @@ class Micro::Case::Result::StepsTest < Minitest::Test
     end
   end
 
-  class MultiplyByTwoUsingThen < Micro::Case
+  class MultiplyByTwoUsingThenWithMethods < Micro::Case
     attributes :number
 
     def call!
       validate_number
-        .then(-> { number.to_f })
-        .then(-> data { multiply_by_two(data[:number]) })
+        .then(method(:normalize_number))
+        .then(method(:multiply_by_two))
     end
 
     private
@@ -100,25 +100,29 @@ class Micro::Case::Result::StepsTest < Minitest::Test
       Kind.of?(Numeric, number) ? Success(:valid) : Failure()
     end
 
+    def normalize_number
+      { normalized_number: number.to_f }
+    end
+
     def multiply_by_two(number)
       Success(result: { number: number * 2 })
     end
   end
 
-  def test_the_then_method_error_when_a_lambda_doesnt_return_a_result
+  def test_the_then_method_error_when_a_method_instance_doesnt_return_a_result
     assert_raises_with_message(
       Micro::Case::Error::UnexpectedResult,
-      /Micro::Case::Result#then\(-> {}\) must return an instance of Micro::Case::Result/
-    ) { MultiplyByTwoUsingThen.call(number: 2) }
+      /MultiplyByTwoUsingThenWithMethods#method\(:normalize_number\) must return an instance of Micro::Case::Result/
+    ) { MultiplyByTwoUsingThenWithMethods.call(number: 2) }
   end
 
-  class DoSomeSumUsingPipe < Micro::Case
-    attributes :a, :b
+  class DoSomeSumUsingPipeWithMethods < Micro::Case
+    attributes :a, :b, number: 4
 
     def call!
       validate_attributes \
-        | -> { sum_a_and_b } \
-        | -> data { add(data, number: 4) } \
+        | method(:sum_a_and_b) \
+        | method(:add) \
         | ThirdSum
     end
 
@@ -132,36 +136,36 @@ class Micro::Case::Result::StepsTest < Minitest::Test
         Success :first_sum, result: { sum: a + b }
       end
 
-      def add(data, number:)
+      def add(data)
         Success :second_sum, result: { sum: data[:sum] + number }
       end
   end
 
-  def test_the_pipe_method_with_lambdas
-    resulta = DoSomeSumUsingPipe.call(a: 1, b: 2)
+  def test_the_pipe_method_with_method_instances
+    resulta = DoSomeSumUsingPipeWithMethods.call(a: 1, b: 2)
 
     assert_success_result(resulta, value: { sum: 7.5 })
 
     [
       {
-        use_case: { class: DoSomeSumUsingPipe, attributes: { a: 1, b: 2 } },
+        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
         success: { type: :valid, result: { valid: true } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :number]
       },
       {
-        use_case: { class: DoSomeSumUsingPipe, attributes: { a: 1, b: 2 } },
+        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
         success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :number]
       },
       {
-        use_case: { class: DoSomeSumUsingPipe, attributes: { a: 1, b: 2 } },
+        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
         success: { type: :second_sum, result: { sum: 7 } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :number]
       },
       {
         use_case: { class: ThirdSum, attributes: { sum: 7 } },
         success: { type: :third_sum, result: { sum: 7.5 } },
-        accessible_attributes: [:a, :b, :sum]
+        accessible_attributes: [:a, :b, :number, :sum]
       }
     ].each_with_index do |transition, index|
       assert_equal(transition, resulta.transitions[index])
@@ -169,28 +173,28 @@ class Micro::Case::Result::StepsTest < Minitest::Test
 
     # ---
 
-    resultb = DoSomeSumUsingPipe.call(a: 1, b: '2')
+    resultb = DoSomeSumUsingPipeWithMethods.call(a: 1, b: '2')
 
     assert_failure_result(resultb, value: { error: true })
 
     [
       {
-        use_case: { class: DoSomeSumUsingPipe, attributes: { a: 1, b: '2' } },
+        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: '2', number: 4 } },
         failure: { type: :error, result: { error: true } },
-        accessible_attributes: [:a, :b]
+        accessible_attributes: [:a, :b, :number]
       }
     ].each_with_index do |transition, index|
       assert_equal(transition, resultb.transitions[index])
     end
   end
 
-  class MultiplyByTwoUsingPipe < Micro::Case
+  class MultiplyByTwoUsingPipeWithMethods < Micro::Case
     attributes :number
 
     def call!
       validate_number \
-        | -> { number.to_f } \
-        | -> data { multiply_by_two(data[:number]) }
+        | method(:normalize_number) \
+        | method(:multiply_by_two)
     end
 
     private
@@ -199,15 +203,19 @@ class Micro::Case::Result::StepsTest < Minitest::Test
       Kind.of?(Numeric, number) ? Success(:valid) : Failure()
     end
 
-    def multiply_by_two(number)
-      Success(result: { number: number * 2 })
+    def normalize_number
+      { normalized_number: number.to_f }
+    end
+
+    def multiply_by_two(data)
+      Success(result: { number: data[:normalized_number] * 2 })
     end
   end
 
-  def test_the_pipe_method_error_when_a_lambda_doesnt_return_a_result
+  def test_the_pipe_method_error_when_a_method_instance_doesnt_return_a_result
     assert_raises_with_message(
       Micro::Case::Error::UnexpectedResult,
-      /Micro::Case::Result#| -> {} must return an instance of Micro::Case::Result/
-    ) { MultiplyByTwoUsingPipe.call(number: 2) }
+      /MultiplyByTwoUsingPipeWithMethods#method\(:normalize_number\) must return an instance of Micro::Case::Result/
+    ) { MultiplyByTwoUsingPipeWithMethods.call(number: 2) }
   end
 end


### PR DESCRIPTION
Close #61

## Definition of done:

- [x] Support Method instances as an alternative to lambdas. Use `Method#arity` to define when it will receive or not the result `#data` values.
- [x] Make the `Micro::Case::Result#then` accumulates the data when receiving a lambda or a method instance.
- [x] Bump version to 3.0.0.rc6
