### PR TITLE
[3.0.0.rc8] Use double splat operator in internal steps that receive a method instance [NEW FEATURE]

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -3,17 +3,21 @@
 ruby_v=$(ruby -v)
 
 ACTIVEMODEL_VERSION='3.2' bundle update
-ACTIVEMODEL_VERSION='3.2' bundle exec rake test
+ACTIVEMODEL_VERSION='3.2' ENABLE_TRANSITIONS='true' bundle exec rake test
+ACTIVEMODEL_VERSION='3.2' ENABLE_TRANSITIONS='false' bundle exec rake test
 
 if [[ ! $ruby_v =~ '2.2.0' ]]; then
   ACTIVEMODEL_VERSION='5.2' bundle update
-  ACTIVEMODEL_VERSION='5.2' bundle exec rake test
+  ACTIVEMODEL_VERSION='5.2' ENABLE_TRANSITIONS='true' bundle exec rake test
+  ACTIVEMODEL_VERSION='5.2' ENABLE_TRANSITIONS='false' bundle exec rake test
 fi
 
 if [[ $ruby_v =~ '2.5.' ]] || [[ $ruby_v =~ '2.6.' ]] || [[ $ruby_v =~ '2.7.' ]]; then
   ACTIVEMODEL_VERSION='6.0' bundle update
-  ACTIVEMODEL_VERSION='6.0' bundle exec rake test
+  ACTIVEMODEL_VERSION='6.0' ENABLE_TRANSITIONS='true' bundle exec rake test
+  ACTIVEMODEL_VERSION='6.0' ENABLE_TRANSITIONS='false' bundle exec rake test
 fi
 
 bundle update
-bundle exec rake test
+ENABLE_TRANSITIONS='true' bundle exec rake test
+ENABLE_TRANSITIONS='false' bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Version   | Documentation
   - [`Micro::Cases::Flow` (v3.0.0)](#microcasesflow-v300)
   - [Comparisons](#comparisons)
 - [Examples](#examples)
-  - [1️⃣ Rails App (API)](#1️⃣-rails-app-api)
-  - [2️⃣ CLI calculator](#2️⃣-cli-calculator)
-  - [3️⃣ Users creation](#3️⃣-users-creation)
+  - [1️⃣ Users creation](#1️⃣-users-creation)
+  - [2️⃣ Rails App (API)](#2️⃣-rails-app-api)
+  - [3️⃣ CLI calculator](#3️⃣-cli-calculator)
   - [4️⃣ Rescuing exceptions inside of the use cases](#4️⃣-rescuing-exceptions-inside-of-the-use-cases)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -1373,23 +1373,23 @@ Check it out implementations of the same use case with different gems/abstractio
 
 ## Examples
 
-### 1️⃣ Rails App (API)
+### 1️⃣ Users creation
+
+> An example of a flow that defines steps to sanitize, validate, and persist its input data. It has all possible approaches to represent use cases using the `u-case` gem.
+>
+> Link: https://github.com/serradura/u-case/blob/main/examples/users_creation
+
+### 2️⃣ Rails App (API)
 
 > This project shows different kinds of architecture (one per commit), and in the last one, how to use the `Micro::Case` gem to handle the application business logic.
 >
 > Link: https://github.com/serradura/from-fat-controllers-to-use-cases
 
-### 2️⃣ CLI calculator
+### 3️⃣ CLI calculator
 
 > Rake tasks to demonstrate how to handle user data, and how to use different failure types to control the program flow.
 >
 > Link: https://github.com/serradura/u-case/tree/main/examples/calculator
-
-### 3️⃣ Users creation
-
-> An example of a use case flow that defines steps to sanitize, validate, and persist its input data.
->
-> Link: https://github.com/serradura/u-case/blob/main/examples/users_creation.rb
 
 ### 4️⃣ Rescuing exceptions inside of the use cases
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The main project goals are:
 
 Version   | Documentation
 --------- | -------------
-3.0.0.rc7 | https://github.com/serradura/u-case/blob/main/README.md
+3.0.0.rc8 | https://github.com/serradura/u-case/blob/main/README.md
 2.6.0     | https://github.com/serradura/u-case/blob/v2.x/README.md
 1.1.0     | https://github.com/serradura/u-case/blob/v1.x/README.md
 
@@ -79,7 +79,7 @@ Version   | Documentation
 
 | u-case         | branch  | ruby     |  activemodel  |
 | -------------- | ------- | -------- | ------------- |
-| 3.0.0.rc7      | main    | >= 2.2.0 | >= 3.2, < 6.1 |
+| 3.0.0.rc8      | main    | >= 2.2.0 | >= 3.2, < 6.1 |
 | 2.6.0          | v2.x    | >= 2.2.0 | >= 3.2, < 6.1 |
 | 1.1.0          | v1.x    | >= 2.2.0 | >= 3.2, < 6.1 |
 
@@ -102,7 +102,7 @@ Version   | Documentation
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'u-case', '~> 3.0.0.rc7'
+gem 'u-case', '~> 3.0.0.rc8'
 ```
 
 And then execute:

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -21,7 +21,7 @@ Principais objetivos deste projeto:
 
 Versão    | Documentação
 --------- | -------------
-3.0.0.rc7 | https://github.com/serradura/u-case/blob/main/README.md
+3.0.0.rc8 | https://github.com/serradura/u-case/blob/main/README.md
 2.6.0     | https://github.com/serradura/u-case/blob/v2.x/README.md
 1.1.0     | https://github.com/serradura/u-case/blob/v1.x/README.md
 
@@ -78,7 +78,7 @@ Versão    | Documentação
 
 | u-case         | branch  | ruby     |  activemodel  |
 | -------------- | ------- | -------- | ------------- |
-| 3.0.0.rc7      | main    | >= 2.2.0 | >= 3.2, < 6.1 |
+| 3.0.0.rc8      | main    | >= 2.2.0 | >= 3.2, < 6.1 |
 | 2.6.0          | v2.x    | >= 2.2.0 | >= 3.2, < 6.1 |
 | 1.1.0          | v1.x    | >= 2.2.0 | >= 3.2, < 6.1 |
 
@@ -101,7 +101,7 @@ Versão    | Documentação
 Adicione essa linha ao Gemfile da sua aplicação:
 
 ```ruby
-gem 'u-case', '~> 3.0.0.rc7'
+gem 'u-case', '~> 3.0.0.rc8'
 ```
 
 E então execute:

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -65,9 +65,9 @@ Versão    | Documentação
   - [`Micro::Cases::Flow` (v3.0.0)](#microcasesflow-v300)
   - [Comparações](#comparações)
 - [Exemplos](#exemplos)
-  - [1️⃣ Rails App (API)](#1️⃣-rails-app-api)
-  - [2️⃣ CLI calculator](#2️⃣-cli-calculator)
-  - [3️⃣ Criação de usuários](#3️⃣-criação-de-usuários)
+  - [1️⃣ Criação de usuários](#1️⃣-criação-de-usuários)
+  - [2️⃣ Rails App (API)](#2️⃣-rails-app-api)
+  - [3️⃣ CLI calculator](#3️⃣-cli-calculator)
   - [4️⃣ Interceptando exceções dentro dos casos de uso](#4️⃣-interceptando-exceções-dentro-dos-casos-de-uso)
 - [Desenvolvimento](#desenvolvimento)
 - [Contribuindo](#contribuindo)
@@ -1377,23 +1377,23 @@ Confira as implementações do mesmo caso de uso com diferentes gems/abstraçõe
 
 ## Exemplos
 
-### 1️⃣ Rails App (API)
+### 1️⃣ Criação de usuários
+
+> Um exemplo de fluxo que define etapas para higienizar, validar e persistir seus dados de entrada. Ele tem todas as abordagens possíveis para representar casos de uso com a gem `u-case`.
+>
+> Link: https://github.com/serradura/u-case/blob/main/examples/users_creation
+
+### 2️⃣ Rails App (API)
 
 > Este projeto mostra diferentes tipos de arquitetura (uma por commit), e na última, como usar a gem `Micro::Case` para lidar com a lógica de negócios da aplicação.
 >
 > Link: https://github.com/serradura/from-fat-controllers-to-use-cases
 
-### 2️⃣ CLI calculator
+### 3️⃣ CLI calculator
 
 > Rake tasks para demonstrar como lidar com os dados do usuário e como usar diferentes tipos de falha para controlar o fluxo do programa.
 >
 > Link: https://github.com/serradura/u-case/tree/main/examples/calculator
-
-### 3️⃣ Criação de usuários
-
-> Um exemplo de fluxo de caso de uso que define etapas para higienizar, validar e persistir seus dados de entrada.
->
-> Link: https://github.com/serradura/u-case/blob/main/examples/users_creation.rb
 
 ### 4️⃣ Interceptando exceções dentro dos casos de uso
 

--- a/benchmarks/flow/with_failure_result.rb
+++ b/benchmarks/flow/with_failure_result.rb
@@ -7,7 +7,7 @@ gemfile do
 
   gem 'interactor', '~> 3.1', '>= 3.1.1'
 
-  gem 'u-case', '~> 3.0.0.rc7'
+  gem 'u-case', '~> 3.0.0.rc8'
 end
 
 require 'benchmark/ips'

--- a/benchmarks/flow/with_success_result.rb
+++ b/benchmarks/flow/with_success_result.rb
@@ -7,7 +7,7 @@ gemfile do
 
   gem 'interactor', '~> 3.1', '>= 3.1.1'
 
-  gem 'u-case', '~> 3.0.0.rc7'
+  gem 'u-case', '~> 3.0.0.rc8'
 end
 
 require 'benchmark/ips'

--- a/benchmarks/use_case/with_failure_result.rb
+++ b/benchmarks/use_case/with_failure_result.rb
@@ -16,7 +16,7 @@ gemfile do
 
   gem 'trailblazer-operation', '~> 0.6.2', require: 'trailblazer/operation'
 
-  gem 'u-case', '~> 3.0.0.rc7'
+  gem 'u-case', '~> 3.0.0.rc8'
 end
 
 require 'benchmark/ips'

--- a/benchmarks/use_case/with_success_result.rb
+++ b/benchmarks/use_case/with_success_result.rb
@@ -16,7 +16,7 @@ gemfile do
 
   gem 'trailblazer-operation', '~> 0.6.2', require: 'trailblazer/operation'
 
-  gem 'u-case', '~> 3.0.0.rc7'
+  gem 'u-case', '~> 3.0.0.rc8'
 end
 
 require 'benchmark/ips'

--- a/examples/calculator/Gemfile
+++ b/examples/calculator/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'rake'
 
-gem 'u-case', '~> 3.0.0.rc7'
+gem 'u-case', '~> 3.0.0.rc8'

--- a/examples/calculator/README.md
+++ b/examples/calculator/README.md
@@ -5,7 +5,7 @@ This example uses [rake](http://rubygems.org/gems/rake) to expose a CLI calculat
 ## Installation instructions
 ```sh
 gem install rake
-gem install u-case -v 3.0.0.rc7
+gem install u-case -v 3.0.0.rc8
 ```
 
 *Note:*

--- a/examples/rescuing_exceptions.rb
+++ b/examples/rescuing_exceptions.rb
@@ -3,7 +3,7 @@ require 'bundler/inline'
 gemfile do
   source 'https://rubygems.org'
 
-  gem 'u-case', '~> 3.0.0.rc7'
+  gem 'u-case', '~> 3.0.0.rc8'
 end
 
 class DivideV1 < Micro::Case

--- a/examples/users_creation/01.rb
+++ b/examples/users_creation/01.rb
@@ -1,0 +1,107 @@
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'activemodel', '~> 6.0'
+
+  gem 'u-case', '~> 3.0.0.rc8'
+end
+
+Micro::Case.config do |config|
+  # Use ActiveModel to auto-validate your use cases' attributes.
+  config.enable_activemodel_validation = true
+
+  # Use to enable/disable the `Micro::Case::Results#transitions` tracking.
+  config.enable_transitions = true
+end
+
+module Users
+  class Entity
+    include Micro::Attributes.with(:initialize)
+
+    attributes :id, :name, :email
+
+    def persisted?
+      !id.nil?
+    end
+  end
+end
+
+module Users::Creation
+  require 'uri'
+  require 'securerandom'
+
+  class Process < Micro::Case
+    attributes :name, :email
+
+    def call!
+      normalized_name = String(name).strip.gsub(/\s+/, ' ')
+      normalized_email = String(email).downcase.strip
+
+      validation_errors = []
+      validation_errors << "Name can't be blank" if normalized_name.blank?
+      validation_errors << "Email is invalid" unless normalized_email.match?(URI::MailTo::EMAIL_REGEXP)
+
+      if validation_errors.present?
+        return Failure :validation_error, result: {
+          errors: OpenStruct.new(full_messages: validation_errors)
+        }
+      end
+
+      user = Users::Entity.new(
+        id: SecureRandom.uuid,
+        name: normalized_name,
+        email: normalized_email
+      )
+
+      Success result: { user_id: user.id, crm_id: sync_with_crm }
+    end
+
+    private def sync_with_crm
+      # Do some integration stuff...
+      SecureRandom.uuid
+    end
+  end
+end
+
+params = {
+  "name" => "  Rodrigo  \n  Serradura ",
+  "email" => "   RoDRIGo.SERRAdura@gmail.com   "
+}
+
+#---------------------------------#
+puts "\n-- Success scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(params)
+  .on_success do |result|
+    user_id, crm_id = result.values_at(:user_id, :crm_id)
+
+    puts " CRM ID: #{crm_id}"
+    puts "USER ID: #{user_id}"
+  end
+
+#---------------------------------#
+puts "\n-- Failure scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(name: '', email: '')
+  .on_failure { |(data, _type)| p data[:errors].full_messages }
+  .on_failure do |_result, use_case|
+    puts "#{use_case.class.name} was the use case responsible for the failure"
+  end
+
+# :: example of the output: ::
+#
+# -- Success scenario --
+#
+#  CRM ID: f3f189f6-ba6a-40ab-998c-c86773c41c83
+# USER ID: c140ffc3-6a7c-4554-972a-c2a0d59f8cb1
+#
+# -- Failure scenarios --
+#
+# ["Name can't be blank", "Email is invalid"]
+# Users::Creation::ValidateParams was the use case responsible for the failure

--- a/examples/users_creation/02a.rb
+++ b/examples/users_creation/02a.rb
@@ -1,0 +1,130 @@
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'activemodel', '~> 6.0'
+
+  gem 'u-case', '~> 3.0.0.rc8'
+end
+
+Micro::Case.config do |config|
+  # Use ActiveModel to auto-validate your use cases' attributes.
+  config.enable_activemodel_validation = true
+
+  # Use to enable/disable the `Micro::Case::Results#transitions` tracking.
+  config.enable_transitions = true
+end
+
+module Users
+  class Entity
+    include Micro::Attributes.with(:initialize)
+
+    attributes :id, :name, :email
+
+    def persisted?
+      !id.nil?
+    end
+  end
+end
+
+module Users::Creation
+  require 'uri'
+  require 'securerandom'
+
+  class Process < Micro::Case
+    attributes :name, :email
+
+    def call!
+      normalize_params
+        .then(-> data { validate_params(data) })
+        .then(-> data { persist(data) })
+        .then(-> data { sync_with_crm(data) })
+    end
+
+    private
+
+      def normalize_params
+        Success result: {
+          name: String(name).strip.gsub(/\s+/, ' '),
+          email: String(email).downcase.strip
+        }
+      end
+
+      def validate_params(data)
+        name, email = data.values_at(:name, :email)
+
+        validation_errors = []
+        validation_errors << "Name can't be blank" if name.blank?
+        validation_errors << "Email is invalid" unless email.match?(URI::MailTo::EMAIL_REGEXP)
+
+        return Success() if validation_errors.blank?
+
+        Failure :validation_error, result: {
+          errors: OpenStruct.new(full_messages: validation_errors)
+        }
+      end
+
+      def persist(data)
+        user_data = data.slice(:name, :email).merge(id: SecureRandom.uuid)
+
+        user = Users::Entity.new(user_data)
+
+        Success result: { user: user }
+      end
+
+      def sync_with_crm(data)
+        user = data.fetch(:user)
+
+        if user.persisted?
+          # Do some integration stuff...
+          crm_id = SecureRandom.uuid
+
+          Success result: { user_id: user.id, crm_id: crm_id }
+        else
+          Failure :crm_error, result: { message: "User can't be sent to the CRM" }
+        end
+      end
+  end
+end
+
+params = {
+  "name" => "  Rodrigo  \n  Serradura ",
+  "email" => "   RoDRIGo.SERRAdura@gmail.com   "
+}
+
+#---------------------------------#
+puts "\n-- Success scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(params)
+  .on_success do |result|
+    user_id, crm_id = result.values_at(:user_id, :crm_id)
+
+    puts " CRM ID: #{crm_id}"
+    puts "USER ID: #{user_id}"
+  end
+
+#---------------------------------#
+puts "\n-- Failure scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(name: '', email: '')
+  .on_failure { |(data, _type)| p data[:errors].full_messages }
+  .on_failure do |_result, use_case|
+    puts "#{use_case.class.name} was the use case responsible for the failure"
+  end
+
+# :: example of the output: ::
+#
+# -- Success scenario --
+#
+#  CRM ID: f3f189f6-ba6a-40ab-998c-c86773c41c83
+# USER ID: c140ffc3-6a7c-4554-972a-c2a0d59f8cb1
+#
+# -- Failure scenarios --
+#
+# ["Name can't be blank", "Email is invalid"]
+# Users::Creation::ValidateParams was the use case responsible for the failure

--- a/examples/users_creation/02b.rb
+++ b/examples/users_creation/02b.rb
@@ -1,0 +1,126 @@
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'activemodel', '~> 6.0'
+
+  gem 'u-case', '~> 3.0.0.rc8'
+end
+
+Micro::Case.config do |config|
+  # Use ActiveModel to auto-validate your use cases' attributes.
+  config.enable_activemodel_validation = true
+
+  # Use to enable/disable the `Micro::Case::Results#transitions` tracking.
+  config.enable_transitions = true
+end
+
+module Users
+  class Entity
+    include Micro::Attributes.with(:initialize)
+
+    attributes :id, :name, :email
+
+    def persisted?
+      !id.nil?
+    end
+  end
+end
+
+module Users::Creation
+  require 'uri'
+  require 'securerandom'
+
+  class Process < Micro::Case
+    attributes :name, :email
+
+    def call!
+      normalize_params
+        .then(method(:validate_params))
+        .then(method(:persist))
+        .then(method(:sync_with_crm))
+    end
+
+    private
+
+      def normalize_params
+        Success result: {
+          name: String(name).strip.gsub(/\s+/, ' '),
+          email: String(email).downcase.strip
+        }
+      end
+
+      def validate_params(name:, email:)
+        validation_errors = []
+        validation_errors << "Name can't be blank" if name.blank?
+        validation_errors << "Email is invalid" unless email.match?(URI::MailTo::EMAIL_REGEXP)
+
+        return Success() if validation_errors.blank?
+
+        Failure :validation_error, result: {
+          errors: OpenStruct.new(full_messages: validation_errors)
+        }
+      end
+
+      def persist(name:, email:, **)
+        user_data = { name: name, email: email, id: SecureRandom.uuid }
+
+        user = Users::Entity.new(user_data)
+
+        Success result: { user: user }
+      end
+
+      def sync_with_crm(user:, **)
+        if user.persisted?
+          # Do some integration stuff...
+          crm_id = SecureRandom.uuid
+
+          Success result: { user_id: user.id, crm_id: crm_id }
+        else
+          Failure :crm_error, result: { message: "User can't be sent to the CRM" }
+        end
+      end
+  end
+end
+
+params = {
+  "name" => "  Rodrigo  \n  Serradura ",
+  "email" => "   RoDRIGo.SERRAdura@gmail.com   "
+}
+
+#---------------------------------#
+puts "\n-- Success scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(params)
+  .on_success do |result|
+    user_id, crm_id = result.values_at(:user_id, :crm_id)
+
+    puts " CRM ID: #{crm_id}"
+    puts "USER ID: #{user_id}"
+  end
+
+#---------------------------------#
+puts "\n-- Failure scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(name: '', email: '')
+  .on_failure { |(data, _type)| p data[:errors].full_messages }
+  .on_failure do |_result, use_case|
+    puts "#{use_case.class.name} was the use case responsible for the failure"
+  end
+
+# :: example of the output: ::
+#
+# -- Success scenario --
+#
+#  CRM ID: f3f189f6-ba6a-40ab-998c-c86773c41c83
+# USER ID: c140ffc3-6a7c-4554-972a-c2a0d59f8cb1
+#
+# -- Failure scenarios --
+#
+# ["Name can't be blank", "Email is invalid"]
+# Users::Creation::ValidateParams was the use case responsible for the failure

--- a/examples/users_creation/03.rb
+++ b/examples/users_creation/03.rb
@@ -1,0 +1,132 @@
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'activemodel', '~> 6.0'
+
+  gem 'u-case', '~> 3.0.0.rc8'
+end
+
+Micro::Case.config do |config|
+  # Use ActiveModel to auto-validate your use cases' attributes.
+  config.enable_activemodel_validation = true
+
+  # Use to enable/disable the `Micro::Case::Results#transitions` tracking.
+  config.enable_transitions = true
+end
+
+module Users
+  class Entity
+    include Micro::Attributes.with(:initialize)
+
+    attributes :id, :name, :email
+
+    def persisted?
+      !id.nil?
+    end
+  end
+end
+
+module Users::Creation
+  class Persist < Micro::Case
+    attributes :name, :email
+
+    validates :name, :email, kind: String
+
+    def call!
+      user_data = attributes.merge(id: SecureRandom.uuid)
+
+      Success result: { user: Users::Entity.new(user_data) }
+    end
+  end
+end
+
+module Users::Creation
+  require 'uri'
+  require 'securerandom'
+
+  class Process < Micro::Case
+    attributes :name, :email
+
+    def call!
+      normalize_params
+        .then(method(:validate_params))
+        .then(Persist)
+        .then(method(:sync_with_crm))
+    end
+
+    private
+
+      def normalize_params
+        Success result: {
+          name: String(name).strip.gsub(/\s+/, ' '),
+          email: String(email).downcase.strip
+        }
+      end
+
+      def validate_params(name:, email:)
+        validation_errors = []
+        validation_errors << "Name can't be blank" if name.blank?
+        validation_errors << "Email is invalid" unless email.match?(URI::MailTo::EMAIL_REGEXP)
+
+        return Success() if validation_errors.blank?
+
+        Failure :validation_error, result: {
+          errors: OpenStruct.new(full_messages: validation_errors)
+        }
+      end
+
+      def sync_with_crm(user:, **)
+        if user.persisted?
+          # Do some integration stuff...
+          crm_id = SecureRandom.uuid
+
+          Success result: { user_id: user.id, crm_id: crm_id }
+        else
+          Failure :crm_error, result: { message: "User can't be sent to the CRM" }
+        end
+      end
+  end
+end
+
+params = {
+  "name" => "  Rodrigo  \n  Serradura ",
+  "email" => "   RoDRIGo.SERRAdura@gmail.com   "
+}
+
+#---------------------------------#
+puts "\n-- Success scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(params)
+  .on_success do |result|
+    user_id, crm_id = result.values_at(:user_id, :crm_id)
+
+    puts " CRM ID: #{crm_id}"
+    puts "USER ID: #{user_id}"
+  end
+
+#---------------------------------#
+puts "\n-- Failure scenario --\n\n"
+#---------------------------------#
+
+Users::Creation::Process
+  .call(name: '', email: '')
+  .on_failure { |(data, _type)| p data[:errors].full_messages }
+  .on_failure do |_result, use_case|
+    puts "#{use_case.class.name} was the use case responsible for the failure"
+  end
+
+# :: example of the output: ::
+#
+# -- Success scenario --
+#
+#  CRM ID: f3f189f6-ba6a-40ab-998c-c86773c41c83
+# USER ID: c140ffc3-6a7c-4554-972a-c2a0d59f8cb1
+#
+# -- Failure scenarios --
+#
+# ["Name can't be blank", "Email is invalid"]
+# Users::Creation::ValidateParams was the use case responsible for the failure

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -72,9 +72,7 @@ module Micro
     def self.__new__(result, arg)
       input = result.__set_transitions_accessible_attributes__(arg)
 
-      instance = new(input)
-      instance.__set_result__(result)
-      instance
+      new(input).__set_result__(result)
     end
 
     def self.__flow_builder__
@@ -135,6 +133,8 @@ module Micro
       raise Error::ResultIsAlreadyDefined if defined?(@__result)
 
       @__result = result
+
+      self
     end
 
     private

--- a/lib/micro/case/config.rb
+++ b/lib/micro/case/config.rb
@@ -15,7 +15,7 @@ module Micro
 
       def enable_transitions=(value)
         Micro::Case::Result.class_variable_set(
-          :@@transition_tracking_enabled, Kind::Of::Boolean(value)
+          :@@transitions_enabled, Kind::Of::Boolean(value)
         )
       end
     end

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -171,7 +171,9 @@ module Micro
               opt ? opt.merge(@__transitions_accumulated_data) : @__transitions_accumulated_data
             )
 
-          fn.arity.zero? ? fn.call : fn.call(input)
+          return fn.call if fn.arity.zero?
+
+          opt ? fn.call(**input) : fn.call(input)
         end
 
         def __call_proc(fn, expected)

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '3.0.0.rc7'.freeze
+    VERSION = '3.0.0.rc8'.freeze
   end
 end

--- a/test/micro/case/internal_steps/with_lambdas_test.rb
+++ b/test/micro/case/internal_steps/with_lambdas_test.rb
@@ -43,29 +43,33 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
 
     assert_success_result(resulta, value: { sum: 6.5 })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
-        success: { type: :valid, result: { valid: true } },
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
-        success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b, :valid]
-      },
-      {
-        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
-        success: { type: :second_sum, result: { sum: 6 } },
-        accessible_attributes: [:a, :b, :valid, :sum]
-      },
-      {
-        use_case: { class: SumHalf, attributes: { sum: 6 } },
-        success: { type: :third_sum, result: { sum: 6.5 } },
-        accessible_attributes: [:a, :b, :valid, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resulta.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
+          success: { type: :valid, result: { valid: true } },
+          accessible_attributes: [:a, :b]
+        },
+        {
+          use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
+          success: { type: :first_sum, result: { sum: 3 } },
+          accessible_attributes: [:a, :b, :valid]
+        },
+        {
+          use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: 2 } },
+          success: { type: :second_sum, result: { sum: 6 } },
+          accessible_attributes: [:a, :b, :valid, :sum]
+        },
+        {
+          use_case: { class: SumHalf, attributes: { sum: 6 } },
+          success: { type: :third_sum, result: { sum: 6.5 } },
+          accessible_attributes: [:a, :b, :valid, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resulta.transitions[index])
+      end
+    else
+      assert_equal([], resulta.transitions)
     end
 
     # ---
@@ -74,14 +78,18 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
 
     assert_failure_result(resultb, value: { error: true })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: '2' } },
-        failure: { type: :error, result: { error: true } },
-        accessible_attributes: [:a, :b]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resultb.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingThenWithLambdas, attributes: { a: 1, b: '2' } },
+          failure: { type: :error, result: { error: true } },
+          accessible_attributes: [:a, :b]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resultb.transitions[index])
+      end
+    else
+      assert_equal([], resultb.transitions)
     end
   end
 
@@ -142,29 +150,33 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
 
     assert_success_result(resulta, value: { sum: 7.5 })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
-        success: { type: :valid, result: { valid: true } },
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
-        success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b, :valid]
-      },
-      {
-        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
-        success: { type: :second_sum, result: { sum: 7 } },
-        accessible_attributes: [:a, :b, :valid, :sum]
-      },
-      {
-        use_case: { class: SumHalf, attributes: { sum: 7 } },
-        success: { type: :third_sum, result: { sum: 7.5 } },
-        accessible_attributes: [:a, :b, :valid, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resulta.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
+          success: { type: :valid, result: { valid: true } },
+          accessible_attributes: [:a, :b]
+        },
+        {
+          use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
+          success: { type: :first_sum, result: { sum: 3 } },
+          accessible_attributes: [:a, :b, :valid]
+        },
+        {
+          use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: 2 } },
+          success: { type: :second_sum, result: { sum: 7 } },
+          accessible_attributes: [:a, :b, :valid, :sum]
+        },
+        {
+          use_case: { class: SumHalf, attributes: { sum: 7 } },
+          success: { type: :third_sum, result: { sum: 7.5 } },
+          accessible_attributes: [:a, :b, :valid, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resulta.transitions[index])
+      end
+    else
+      assert_equal([], resulta.transitions)
     end
 
     # ---
@@ -173,14 +185,18 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
 
     assert_failure_result(resultb, value: { error: true })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: '2' } },
-        failure: { type: :error, result: { error: true } },
-        accessible_attributes: [:a, :b]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resultb.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingPipeWithLambdas, attributes: { a: 1, b: '2' } },
+          failure: { type: :error, result: { error: true } },
+          accessible_attributes: [:a, :b]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resultb.transitions[index])
+      end
+    else
+      assert_equal([], resultb.transitions)
     end
   end
 
@@ -243,37 +259,41 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
 
     assert_success_result(result, value: { sum: 10.5 })
 
-    [
-      {
-        use_case: {
-          class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2 }
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2 }
+          },
+          success: {type: :c, result: { c: 3 }},
+          accessible_attributes: [:a, :b]
         },
-        success: {type: :c, result: { c: 3 }},
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2 }
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2 }
+          },
+          success: { type: :d, result: { d: 4 }},
+          accessible_attributes: [:a, :b, :c]
         },
-        success: { type: :d, result: { d: 4 }},
-        accessible_attributes: [:a, :b, :c]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2}
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithLambdas, attributes: { a: 1, b: 2}
+          },
+          success: { type: :sum_a_b_c_d, result: { sum: 10 }},
+          accessible_attributes: [:a, :b, :c, :d]
         },
-        success: { type: :sum_a_b_c_d, result: { sum: 10 }},
-        accessible_attributes: [:a, :b, :c, :d]
-      },
-      {
-        use_case: {
-          class: SumHalf, attributes: { sum: 10 }
-        },
-        success: { type: :third_sum, result: { sum: 10.5 }},
-        accessible_attributes: [:a, :b, :c, :d, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, result.transitions[index])
+        {
+          use_case: {
+            class: SumHalf, attributes: { sum: 10 }
+          },
+          success: { type: :third_sum, result: { sum: 10.5 }},
+          accessible_attributes: [:a, :b, :c, :d, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, result.transitions[index])
+      end
+    else
+      assert_equal([], result.transitions)
     end
   end
 
@@ -309,37 +329,41 @@ class Micro::Case::InternalStepsWithLambdasTest < Minitest::Test
 
     assert_success_result(result, value: { sum: 11.5 })
 
-    [
-      {
-        use_case: {
-          class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2 }
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2 }
+          },
+          success: {type: :c, result: { c: 3 }},
+          accessible_attributes: [:a, :b]
         },
-        success: {type: :c, result: { c: 3 }},
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2 }
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2 }
+          },
+          success: { type: :d, result: { d: 4 }},
+          accessible_attributes: [:a, :b, :c]
         },
-        success: { type: :d, result: { d: 4 }},
-        accessible_attributes: [:a, :b, :c]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2}
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithLambdas, attributes: { a: 2, b: 2}
+          },
+          success: { type: :sum_a_b_c_d, result: { sum: 11 }},
+          accessible_attributes: [:a, :b, :c, :d]
         },
-        success: { type: :sum_a_b_c_d, result: { sum: 11 }},
-        accessible_attributes: [:a, :b, :c, :d]
-      },
-      {
-        use_case: {
-          class: SumHalf, attributes: { sum: 11 }
-        },
-        success: { type: :third_sum, result: { sum: 11.5 }},
-        accessible_attributes: [:a, :b, :c, :d, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, result.transitions[index])
+        {
+          use_case: {
+            class: SumHalf, attributes: { sum: 11 }
+          },
+          success: { type: :third_sum, result: { sum: 11.5 }},
+          accessible_attributes: [:a, :b, :c, :d, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, result.transitions[index])
+      end
+    else
+      assert_equal([], result.transitions)
     end
   end
 end

--- a/test/micro/case/internal_steps/with_methods_test.rb
+++ b/test/micro/case/internal_steps/with_methods_test.rb
@@ -43,29 +43,33 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
 
     assert_success_result(resulta, value: { sum: 6.5 })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
-        success: { type: :valid, result: { valid: true } },
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
-        success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b, :valid]
-      },
-      {
-        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
-        success: { type: :second_sum, result: { sum: 6 } },
-        accessible_attributes: [:a, :b, :valid, :number, :sum]
-      },
-      {
-        use_case: { class: SumHalf, attributes: { sum: 6 } },
-        success: { type: :third_sum, result: { sum: 6.5 } },
-        accessible_attributes: [:a, :b, :valid, :number, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resulta.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
+          success: { type: :valid, result: { valid: true } },
+          accessible_attributes: [:a, :b]
+        },
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
+          success: { type: :first_sum, result: { sum: 3 } },
+          accessible_attributes: [:a, :b, :valid]
+        },
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
+          success: { type: :second_sum, result: { sum: 6 } },
+          accessible_attributes: [:a, :b, :valid, :number, :sum]
+        },
+        {
+          use_case: { class: SumHalf, attributes: { sum: 6 } },
+          success: { type: :third_sum, result: { sum: 6.5 } },
+          accessible_attributes: [:a, :b, :valid, :number, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resulta.transitions[index])
+      end
+    else
+      assert_equal([], resulta.transitions)
     end
 
     # ---
@@ -74,14 +78,18 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
 
     assert_failure_result(resultb, value: { error: true })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: '2' } },
-        failure: { type: :error, result: { error: true } },
-        accessible_attributes: [:a, :b]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resultb.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: '2' } },
+          failure: { type: :error, result: { error: true } },
+          accessible_attributes: [:a, :b]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resultb.transitions[index])
+      end
+    else
+      assert_equal([], resultb.transitions)
     end
   end
 
@@ -146,29 +154,33 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
 
     assert_success_result(resulta, value: { sum: 7.5 })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
-        success: { type: :valid, result: { valid: true } },
-        accessible_attributes: [:a, :b, :number]
-      },
-      {
-        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
-        success: { type: :first_sum, result: { sum: 3 } },
-        accessible_attributes: [:a, :b, :number, :valid]
-      },
-      {
-        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
-        success: { type: :second_sum, result: { sum: 7 } },
-        accessible_attributes: [:a, :b, :number, :valid, :sum]
-      },
-      {
-        use_case: { class: SumHalf, attributes: { sum: 7 } },
-        success: { type: :third_sum, result: { sum: 7.5 } },
-        accessible_attributes: [:a, :b, :number, :valid, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resulta.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
+          success: { type: :valid, result: { valid: true } },
+          accessible_attributes: [:a, :b, :number]
+        },
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
+          success: { type: :first_sum, result: { sum: 3 } },
+          accessible_attributes: [:a, :b, :number, :valid]
+        },
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
+          success: { type: :second_sum, result: { sum: 7 } },
+          accessible_attributes: [:a, :b, :number, :valid, :sum]
+        },
+        {
+          use_case: { class: SumHalf, attributes: { sum: 7 } },
+          success: { type: :third_sum, result: { sum: 7.5 } },
+          accessible_attributes: [:a, :b, :number, :valid, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resulta.transitions[index])
+      end
+    else
+      assert_equal([], resulta.transitions)
     end
 
     # ---
@@ -177,14 +189,18 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
 
     assert_failure_result(resultb, value: { error: true })
 
-    [
-      {
-        use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: '2', number: 4 } },
-        failure: { type: :error, result: { error: true } },
-        accessible_attributes: [:a, :b, :number]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, resultb.transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: '2', number: 4 } },
+          failure: { type: :error, result: { error: true } },
+          accessible_attributes: [:a, :b, :number]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resultb.transitions[index])
+      end
+    else
+      assert_equal([], resultb.transitions)
     end
   end
 
@@ -251,37 +267,41 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
 
     assert_success_result(result, value: { sum: 10.5 })
 
-    [
-      {
-        use_case: {
-          class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+          },
+          success: {type: :c, result: { c: 3 }},
+          accessible_attributes: [:a, :b]
         },
-        success: {type: :c, result: { c: 3 }},
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+          },
+          success: { type: :d, result: { d: 4 }},
+          accessible_attributes: [:a, :b, :c]
         },
-        success: { type: :d, result: { d: 4 }},
-        accessible_attributes: [:a, :b, :c]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2}
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2}
+          },
+          success: { type: :sum_a_b_c_d, result: { sum: 10 }},
+          accessible_attributes: [:a, :b, :c, :d]
         },
-        success: { type: :sum_a_b_c_d, result: { sum: 10 }},
-        accessible_attributes: [:a, :b, :c, :d]
-      },
-      {
-        use_case: {
-          class: SumHalf, attributes: { sum: 10 }
-        },
-        success: { type: :third_sum, result: { sum: 10.5 }},
-        accessible_attributes: [:a, :b, :c, :d, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, result.transitions[index])
+        {
+          use_case: {
+            class: SumHalf, attributes: { sum: 10 }
+          },
+          success: { type: :third_sum, result: { sum: 10.5 }},
+          accessible_attributes: [:a, :b, :c, :d, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, result.transitions[index])
+      end
+    else
+      assert_equal([], result.transitions)
     end
   end
 
@@ -317,37 +337,41 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
 
     assert_success_result(result, value: { sum: 11.5 })
 
-    [
-      {
-        use_case: {
-          class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+          },
+          success: {type: :c, result: { c: 3 }},
+          accessible_attributes: [:a, :b]
         },
-        success: {type: :c, result: { c: 3 }},
-        accessible_attributes: [:a, :b]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+          },
+          success: { type: :d, result: { d: 4 }},
+          accessible_attributes: [:a, :b, :c]
         },
-        success: { type: :d, result: { d: 4 }},
-        accessible_attributes: [:a, :b, :c]
-      },
-      {
-        use_case: {
-          class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2}
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2}
+          },
+          success: { type: :sum_a_b_c_d, result: { sum: 11 }},
+          accessible_attributes: [:a, :b, :c, :d]
         },
-        success: { type: :sum_a_b_c_d, result: { sum: 11 }},
-        accessible_attributes: [:a, :b, :c, :d]
-      },
-      {
-        use_case: {
-          class: SumHalf, attributes: { sum: 11 }
-        },
-        success: { type: :third_sum, result: { sum: 11.5 }},
-        accessible_attributes: [:a, :b, :c, :d, :sum]
-      }
-    ].each_with_index do |transition, index|
-      assert_equal(transition, result.transitions[index])
+        {
+          use_case: {
+            class: SumHalf, attributes: { sum: 11 }
+          },
+          success: { type: :third_sum, result: { sum: 11.5 }},
+          accessible_attributes: [:a, :b, :c, :d, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, result.transitions[index])
+      end
+    else
+      assert_equal([], result.transitions)
     end
   end
 end

--- a/test/micro/case/result/then_test.rb
+++ b/test/micro/case/result/then_test.rb
@@ -95,29 +95,33 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_success_result(result1, value: { number: 3 })
 
-    expected_transitions1 = [
-      {
-        use_case: {
-          class: ConvertTextIntoInteger, attributes: { text: '0'}
+    if ::Micro::Case::Result.transitions_enabled?
+      expected_transitions1 = [
+        {
+          use_case: {
+            class: ConvertTextIntoInteger, attributes: { text: '0'}
+          },
+          success: {
+            type: :ok, result: { number: 0 }
+          },
+          accessible_attributes: [:text]
         },
-        success: {
-          type: :ok, result: { number: 0 }
-        },
-        accessible_attributes: [:text]
-      },
-      {
-        use_case: {
-          class: Add3, attributes: { number: 0 }
-        },
-        success: {
-          type: :ok, result: { number: 3 }
-        },
-        accessible_attributes: [:text, :number]
-      }
-    ]
+        {
+          use_case: {
+            class: Add3, attributes: { number: 0 }
+          },
+          success: {
+            type: :ok, result: { number: 3 }
+          },
+          accessible_attributes: [:text, :number]
+        }
+      ]
 
-    result1.transitions.each_with_index do |transition, index|
-      assert_equal(expected_transitions1[index], transition)
+      result1.transitions.each_with_index do |transition, index|
+        assert_equal(expected_transitions1[index], transition)
+      end
+    else
+      assert_equal([], result1.transitions)
     end
 
     # ---
@@ -126,21 +130,25 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     assert_failure_result(result2, value: { text_isnt_a_string_only_with_numbers: true })
 
-    expected_transitions2 = [
-      {
-        use_case: {
-          class: ConvertTextIntoInteger, attributes: { text: 0}
-        },
-        failure: {
-          type: :text_isnt_a_string_only_with_numbers,
-          result: { text_isnt_a_string_only_with_numbers: true }
-        },
-        accessible_attributes: [:text]
-      }
-    ]
+    if ::Micro::Case::Result.transitions_enabled?
+      expected_transitions2 = [
+        {
+          use_case: {
+            class: ConvertTextIntoInteger, attributes: { text: 0}
+          },
+          failure: {
+            type: :text_isnt_a_string_only_with_numbers,
+            result: { text_isnt_a_string_only_with_numbers: true }
+          },
+          accessible_attributes: [:text]
+        }
+      ]
 
-    result2.transitions.each_with_index do |transition, index|
-      assert_equal(expected_transitions2[index], transition)
+      result2.transitions.each_with_index do |transition, index|
+        assert_equal(expected_transitions2[index], transition)
+      end
+    else
+      assert_equal([], result2.transitions)
     end
   end
 
@@ -205,24 +213,28 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result1_transitions = result1.transitions
 
-    [
-      {
-        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
-        accessible_attributes: [:foo, :bar]
-      },
-      {
-        use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, result: { filled_foo: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo_and_bar]
-      },
-      {
-        use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, result: { filled_bar: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :filled_foo]
-      }
-    ].each_with_index do |expected_transition, index|
-      assert_equal(expected_transition, result1_transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+          success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
+          accessible_attributes: [:foo, :bar]
+        },
+        {
+          use_case: { class: Foo, attributes: { foo: 'foo' } },
+          success: { type: :filled_foo, result: { filled_foo: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo_and_bar]
+        },
+        {
+          use_case: { class: Bar, attributes: { bar: 'bar' }},
+          success: { type: :filled_bar, result: { filled_bar: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :filled_foo]
+        }
+      ].each_with_index do |expected_transition, index|
+        assert_equal(expected_transition, result1_transitions[index])
+      end
+    else
+      assert_equal([], result1_transitions)
     end
 
     # ---
@@ -237,29 +249,33 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result2_transitions = result2.transitions
 
-    [
-      {
-        use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, result: { filled_foo: true } },
-        accessible_attributes: [:foo, :bar]
-      },
-      {
-        use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, result: { filled_bar: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo]
-      },
-      {
-        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar]
-      },
-      {
-        use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, result: { filled_bar: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :filled_foo_and_bar]
-      },
-    ].each_with_index do |expected_transition, index|
-      assert_equal(expected_transition, result2_transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: Foo, attributes: { foo: 'foo' } },
+          success: { type: :filled_foo, result: { filled_foo: true } },
+          accessible_attributes: [:foo, :bar]
+        },
+        {
+          use_case: { class: Bar, attributes: { bar: 'bar' }},
+          success: { type: :filled_bar, result: { filled_bar: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo]
+        },
+        {
+          use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+          success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar]
+        },
+        {
+          use_case: { class: Bar, attributes: { bar: 'bar' }},
+          success: { type: :filled_bar, result: { filled_bar: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :filled_foo_and_bar]
+        },
+      ].each_with_index do |expected_transition, index|
+        assert_equal(expected_transition, result2_transitions[index])
+      end
+    else
+      assert_equal([], result2_transitions)
     end
   end
 
@@ -273,19 +289,23 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result1_transitions = result1.transitions
 
-    [
-      {
-        use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, result: { filled_foo: true } },
-        accessible_attributes: [:foo]
-      },
-      {
-        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
-        accessible_attributes: [:foo, :filled_foo, :bar]
-      }
-    ].each_with_index do |expected_transition, index|
-      assert_equal(expected_transition, result1_transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: Foo, attributes: { foo: 'foo' } },
+          success: { type: :filled_foo, result: { filled_foo: true } },
+          accessible_attributes: [:foo]
+        },
+        {
+          use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+          success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
+          accessible_attributes: [:foo, :filled_foo, :bar]
+        }
+      ].each_with_index do |expected_transition, index|
+        assert_equal(expected_transition, result1_transitions[index])
+      end
+    else
+      assert_equal([], result1_transitions)
     end
 
     # ---
@@ -299,19 +319,23 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result2_transitions = result2.transitions
 
-    [
-      {
-        use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, result: { filled_bar: true } },
-        accessible_attributes: [:bar]
-      },
-      {
-        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
-        accessible_attributes: [:bar, :filled_bar, :foo]
-      }
-    ].each_with_index do |expected_transition, index|
-      assert_equal(expected_transition, result2_transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: Bar, attributes: { bar: 'bar' }},
+          success: { type: :filled_bar, result: { filled_bar: true } },
+          accessible_attributes: [:bar]
+        },
+        {
+          use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+          success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
+          accessible_attributes: [:bar, :filled_bar, :foo]
+        }
+      ].each_with_index do |expected_transition, index|
+        assert_equal(expected_transition, result2_transitions[index])
+      end
+    else
+      assert_equal([], result2_transitions)
     end
 
     # ---
@@ -325,19 +349,23 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result3_transitions = result3.transitions
 
-    [
-      {
-        use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
-        success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
-        accessible_attributes: [:foo, :bar]
-      },
-      {
-        use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :filled_foo_and_bar_and_baz, result: { filled_foo_and_bar_and_baz: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :baz]
-      },
-    ].each_with_index do |expected_transition, index|
-      assert_equal(expected_transition, result3_transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: FooBar, attributes: { foo: 'foo', bar: 'bar'} },
+          success: { type: :filled_foo_and_bar, result: { filled_foo_and_bar: true } },
+          accessible_attributes: [:foo, :bar]
+        },
+        {
+          use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
+          success: { type: :filled_foo_and_bar_and_baz, result: { filled_foo_and_bar_and_baz: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo_and_bar, :baz]
+        },
+      ].each_with_index do |expected_transition, index|
+        assert_equal(expected_transition, result3_transitions[index])
+      end
+    else
+      assert_equal([], result3_transitions)
     end
 
     # ---
@@ -351,24 +379,28 @@ class Micro::Case::Result::ThenTest < Minitest::Test
 
     result4_transitions = result4.transitions
 
-    [
-      {
-        use_case: { class: Foo, attributes: { foo: 'foo' } },
-        success: { type: :filled_foo, result: { filled_foo: true } },
-        accessible_attributes: [:foo, :bar]
-      },
-      {
-        use_case: { class: Bar, attributes: { bar: 'bar' }},
-        success: { type: :filled_bar, result: { filled_bar: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo]
-      },
-      {
-        use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
-        success: { type: :filled_foo_and_bar_and_baz, result: { filled_foo_and_bar_and_baz: true } },
-        accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :baz]
-      },
-    ].each_with_index do |expected_transition, index|
-      assert_equal(expected_transition, result4_transitions[index])
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: Foo, attributes: { foo: 'foo' } },
+          success: { type: :filled_foo, result: { filled_foo: true } },
+          accessible_attributes: [:foo, :bar]
+        },
+        {
+          use_case: { class: Bar, attributes: { bar: 'bar' }},
+          success: { type: :filled_bar, result: { filled_bar: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo]
+        },
+        {
+          use_case: { class: FooBarBaz, attributes: { foo: 'foo', bar: 'bar', baz: 'baz'} },
+          success: { type: :filled_foo_and_bar_and_baz, result: { filled_foo_and_bar_and_baz: true } },
+          accessible_attributes: [:foo, :bar, :filled_foo, :filled_bar, :baz]
+        },
+      ].each_with_index do |expected_transition, index|
+        assert_equal(expected_transition, result4_transitions[index])
+      end
+    else
+      assert_equal([], result4_transitions)
     end
   end
 end

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -46,13 +46,15 @@ class Micro::Case::ResultTest < Minitest::Test
 
     # ---
 
-    assert_equal(result.transitions, [
-      {
-        use_case: { class: Micro::Case, attributes: {} },
-        success: { type: :ok, result: { a: 1, b: 2 } },
-        accessible_attributes: []
-      }
-    ])
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(result.transitions, [
+        {
+          use_case: { class: Micro::Case, attributes: {} },
+          success: { type: :ok, result: { a: 1, b: 2 } },
+          accessible_attributes: []
+        }
+      ])
+    end
 
     # ---
 
@@ -107,13 +109,15 @@ class Micro::Case::ResultTest < Minitest::Test
 
     # ---
 
-    assert_equal(result.transitions, [
-      {
-        use_case: { class: Micro::Case, attributes: {} },
-        failure: { type: :error, result: { a: 0, b: -1 } },
-        accessible_attributes: []
-      }
-    ])
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(result.transitions, [
+        {
+          use_case: { class: Micro::Case, attributes: {} },
+          failure: { type: :error, result: { a: 0, b: -1 } },
+          accessible_attributes: []
+        }
+      ])
+    end
 
     # ---
 
@@ -256,10 +260,8 @@ class Micro::Case::ResultTest < Minitest::Test
       end
   end
 
-  def test_the_disable_transition_tracking_config
-    Micro::Case.config do |config|
-      config.enable_transitions = false
-    end
+  def test_the_result_when_transitions_are_disabled
+    return if ::Micro::Case::Result.transitions_enabled?
 
     result = success_result(value: { number: 1 }, type: :ok)
 
@@ -274,9 +276,5 @@ class Micro::Case::ResultTest < Minitest::Test
     result2 = Add2ToAllNumbers.call(numbers: %w[1 1 2 2 c 4])
 
     assert_failure_result(result2, value: { numbers: 'must contain only numeric types' })
-
-    Micro::Case.config do |config|
-      config.enable_transitions = true
-    end
   end
 end

--- a/test/micro/cases/flow/result_transitions_test.rb
+++ b/test/micro/cases/flow/result_transitions_test.rb
@@ -81,113 +81,117 @@ class Micro::Cases::Flow::ResultTransitionsTest < Minitest::Test
 
     result_transitions = todo_created.transitions
 
-    assert_equal(3, result_transitions.size)
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(3, result_transitions.size)
 
-    # --------------
-    # transitions[0]
-    # --------------
+      # --------------
+      # transitions[0]
+      # --------------
 
-    first_transition = result_transitions[0]
+      first_transition = result_transitions[0]
 
-    # transitions[0][:use_case]
-    first_transition_use_case = first_transition[:use_case]
+      # transitions[0][:use_case]
+      first_transition_use_case = first_transition[:use_case]
 
-    # transitions[0][:use_case][:class]
-    assert_equal(Users::Find, first_transition_use_case[:class])
+      # transitions[0][:use_case][:class]
+      assert_equal(Users::Find, first_transition_use_case[:class])
 
-    # transitions[0][:use_case][:attributes]
-    assert_equal([:email], first_transition_use_case[:attributes].keys)
+      # transitions[0][:use_case][:attributes]
+      assert_equal([:email], first_transition_use_case[:attributes].keys)
 
-    assert_instance_of(String, first_transition_use_case[:attributes][:email])
+      assert_instance_of(String, first_transition_use_case[:attributes][:email])
 
-    # transitions[0][:success]
-    assert(first_transition.include?(:success))
+      # transitions[0][:success]
+      assert(first_transition.include?(:success))
 
-    first_transition_result = first_transition[:success]
+      first_transition_result = first_transition[:success]
 
-    # transitions[0][:success][:type]
-    assert_equal(:ok, first_transition_result[:type])
+      # transitions[0][:success][:type]
+      assert_equal(:ok, first_transition_result[:type])
 
-    # transitions[0][:success][:result]
-    assert_equal([:user], first_transition_result[:result].keys)
+      # transitions[0][:success][:result]
+      assert_equal([:user], first_transition_result[:result].keys)
 
-    assert_instance_of(User, first_transition_result[:result][:user])
+      assert_instance_of(User, first_transition_result[:result][:user])
 
-    # transitions[0][:accessible_attributes]
-    assert_equal([:email, :password, :description], first_transition[:accessible_attributes])
+      # transitions[0][:accessible_attributes]
+      assert_equal([:email, :password, :description], first_transition[:accessible_attributes])
 
-    # --------------
-    # transitions[1]
-    # --------------
+      # --------------
+      # transitions[1]
+      # --------------
 
-    second_transition = result_transitions[1]
+      second_transition = result_transitions[1]
 
-    # transitions[1][:use_case]
-    second_transition_use_case = second_transition[:use_case]
+      # transitions[1][:use_case]
+      second_transition_use_case = second_transition[:use_case]
 
-    # transitions[1][:use_case][:class]
-    assert_equal(Users::ValidatePassword, second_transition_use_case[:class])
+      # transitions[1][:use_case][:class]
+      assert_equal(Users::ValidatePassword, second_transition_use_case[:class])
 
-    # transitions[1][:use_case][:attributes]
-    assert_equal([:user, :password], second_transition_use_case[:attributes].keys)
+      # transitions[1][:use_case][:attributes]
+      assert_equal([:user, :password], second_transition_use_case[:attributes].keys)
 
-    assert_instance_of(User, second_transition_use_case[:attributes][:user])
-    assert_instance_of(String, second_transition_use_case[:attributes][:password])
+      assert_instance_of(User, second_transition_use_case[:attributes][:user])
+      assert_instance_of(String, second_transition_use_case[:attributes][:password])
 
-    # transitions[1][:success]
-    assert(second_transition.include?(:success))
+      # transitions[1][:success]
+      assert(second_transition.include?(:success))
 
-    second_transition_result = second_transition[:success]
+      second_transition_result = second_transition[:success]
 
-    # transitions[1][:success][:type]
-    assert_equal(:ok, second_transition_result[:type])
+      # transitions[1][:success][:type]
+      assert_equal(:ok, second_transition_result[:type])
 
-    # transitions[1][:success][:result]
-    assert_equal([:user], second_transition_result[:result].keys)
+      # transitions[1][:success][:result]
+      assert_equal([:user], second_transition_result[:result].keys)
 
-    assert_instance_of(User, second_transition_result[:result][:user])
+      assert_instance_of(User, second_transition_result[:result][:user])
 
-    # transitions[1][:accessible_attributes]
-    assert_equal([:email, :password, :description, :user], second_transition[:accessible_attributes])
+      # transitions[1][:accessible_attributes]
+      assert_equal([:email, :password, :description, :user], second_transition[:accessible_attributes])
 
-    # --------------
-    # transitions[2]
-    # --------------
+      # --------------
+      # transitions[2]
+      # --------------
 
-    third_transition = result_transitions[2]
+      third_transition = result_transitions[2]
 
-    # transitions[2][:use_case]
-    third_transition_use_case = third_transition[:use_case]
+      # transitions[2][:use_case]
+      third_transition_use_case = third_transition[:use_case]
 
-    # transitions[2][:use_case][:class]
-    assert_equal(Todos::Create, third_transition_use_case[:class])
+      # transitions[2][:use_case][:class]
+      assert_equal(Todos::Create, third_transition_use_case[:class])
 
-    # transitions[2][:use_case][:attributes]
-    assert_equal([:user, :description], third_transition_use_case[:attributes].keys)
+      # transitions[2][:use_case][:attributes]
+      assert_equal([:user, :description], third_transition_use_case[:attributes].keys)
 
-    assert_instance_of(User, third_transition_use_case[:attributes][:user])
+      assert_instance_of(User, third_transition_use_case[:attributes][:user])
 
-    assert_instance_of(String, third_transition_use_case[:attributes][:description])
-    assert_equal('Buy milk', third_transition_use_case[:attributes][:description])
+      assert_instance_of(String, third_transition_use_case[:attributes][:description])
+      assert_equal('Buy milk', third_transition_use_case[:attributes][:description])
 
-    # transitions[2][:success]
-    assert(third_transition.include?(:success))
+      # transitions[2][:success]
+      assert(third_transition.include?(:success))
 
-    third_transition_result = third_transition[:success]
+      third_transition_result = third_transition[:success]
 
-    # transitions[2][:success][:type]
-    assert_equal(:ok, third_transition_result[:type])
+      # transitions[2][:success][:type]
+      assert_equal(:ok, third_transition_result[:type])
 
-    # transitions[2][:success][:result]
-    assert_equal([:todo], third_transition_result[:result].keys)
+      # transitions[2][:success][:result]
+      assert_equal([:todo], third_transition_result[:result].keys)
 
-    assert_instance_of(Todo, third_transition_result[:result][:todo])
-    assert_equal(
-      third_transition_use_case[:attributes][:description],
-      third_transition_result[:result][:todo].description
-    )
+      assert_instance_of(Todo, third_transition_result[:result][:todo])
+      assert_equal(
+        third_transition_use_case[:attributes][:description],
+        third_transition_result[:result][:todo].description
+      )
 
-    # transitions[2][:accessible_attributes]
-    assert_equal([:email, :password, :description, :user], third_transition[:accessible_attributes])
+      # transitions[2][:accessible_attributes]
+      assert_equal([:email, :password, :description, :user], third_transition[:accessible_attributes])
+    else
+      assert_equal([], result_transitions)
+    end
   end
 end

--- a/test/micro/cases/flow_test.rb
+++ b/test/micro/cases/flow_test.rb
@@ -14,92 +14,96 @@ class Micro::Cases::FlowTest < Minitest::Test
 
     result1_transitions = result1.transitions
 
-    assert_equal(4, result1_transitions.size)
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(4, result1_transitions.size)
 
-    {
-      0 => {
-        use_case: -> use_case do
-          assert_equal(Jobs::Build::Self, use_case[:class])
+      {
+        0 => {
+          use_case: -> use_case do
+            assert_equal(Jobs::Build::Self, use_case[:class])
 
-          assert_equal({}, use_case[:attributes])
-        end,
-        success: -> success do
-          assert_equal(:ok, success[:type])
+            assert_equal({}, use_case[:attributes])
+          end,
+          success: -> success do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_nil(job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([], keys) }
-      },
-      1 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::SetID, use_case[:class])
+            assert_nil(job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([], keys) }
+        },
+        1 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::SetID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success) do
-          assert_equal(:ok, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success) do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      2 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::ValidateID, use_case[:class])
+            assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        2 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::ValidateID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) { assert_equal(previous[:success], success) },
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      3 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::SetStateToRunning, use_case[:class])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) { assert_equal(previous[:success], success) },
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        3 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::SetStateToRunning, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) do
-          assert_equal(:state_updated, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) do
+            assert_equal(:state_updated, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job, :changes], result.keys)
+            assert_equal([:job, :changes], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_equal(previous[:success][:result][:job].id, job.id)
-          assert_predicate(job, :running?)
+            assert_equal(previous[:success][:result][:job].id, job.id)
+            assert_predicate(job, :running?)
 
-          result[:changes].changed?(:state, from: 'sleeping', to: 'running')
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      }
-    }.each do |index, transition_assertions|
-      transition_assertions.each do |key, assertion|
-        transition_scope = result1_transitions[index][key]
+            result[:changes].changed?(:state, from: 'sleeping', to: 'running')
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        }
+      }.each do |index, transition_assertions|
+        transition_assertions.each do |key, assertion|
+          transition_scope = result1_transitions[index][key]
 
-        if assertion.arity == 1
-          assertion.call(transition_scope)
-        else
-          previous_transition = result1_transitions[index - 1] if index != 0
+          if assertion.arity == 1
+            assertion.call(transition_scope)
+          else
+            previous_transition = result1_transitions[index - 1] if index != 0
 
-          assertion.call(transition_scope, previous_transition)
+            assertion.call(transition_scope, previous_transition)
+          end
         end
       end
+    else
+      assert_equal([], result1_transitions)
     end
 
     # ---
@@ -112,128 +116,132 @@ class Micro::Cases::FlowTest < Minitest::Test
           assert_equal({ invalid_state_transition: true }, value)
         end
 
-    result2_transitions = result2.transitions
+      result2_transitions = result2.transitions
 
-    assert_equal(6, result2_transitions.size)
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(6, result2_transitions.size)
 
-    {
-      0 => {
-        use_case: -> use_case do
-          assert_equal(Jobs::Build::Self, use_case[:class])
+      {
+        0 => {
+          use_case: -> use_case do
+            assert_equal(Jobs::Build::Self, use_case[:class])
 
-          assert_equal({}, use_case[:attributes])
-        end,
-        success: -> success do
-          assert_equal(:ok, success[:type])
+            assert_equal({}, use_case[:attributes])
+          end,
+          success: -> success do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_nil(job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([], keys) }
-      },
-      1 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::SetID, use_case[:class])
+            assert_nil(job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([], keys) }
+        },
+        1 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::SetID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success) do
-          assert_equal(:ok, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success) do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      2 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::ValidateID, use_case[:class])
+            assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        2 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::ValidateID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) { assert_equal(previous[:success], success) },
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      3 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::SetStateToRunning, use_case[:class])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) { assert_equal(previous[:success], success) },
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        3 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::SetStateToRunning, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) do
-          assert_equal(:state_updated, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) do
+            assert_equal(:state_updated, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job, :changes], result.keys)
+            assert_equal([:job, :changes], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_equal(previous[:success][:result][:job].id, job.id)
-          assert_predicate(job, :running?)
+            assert_equal(previous[:success][:result][:job].id, job.id)
+            assert_predicate(job, :running?)
 
-          result[:changes].changed?(:state, from: 'sleeping', to: 'running')
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      4 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::ValidateID, use_case[:class])
+            result[:changes].changed?(:state, from: 'sleeping', to: 'running')
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        4 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::ValidateID, use_case[:class])
 
-          attributes = use_case[:attributes]
+            attributes = use_case[:attributes]
 
-          assert_equal([:job], attributes.keys)
+            assert_equal([:job], attributes.keys)
 
-          assert_equal(previous[:success][:result][:job], attributes[:job])
-        end,
-        success: -> (success, previous) do
-          assert_equal(:ok, success[:type])
+            assert_equal(previous[:success][:result][:job], attributes[:job])
+          end,
+          success: -> (success, previous) do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          assert_equal(previous[:success][:result][:job], result[:job])
-        end,
-        accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
-      },
-      5 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Jobs::SetStateToRunning, use_case[:class])
+            assert_equal(previous[:success][:result][:job], result[:job])
+          end,
+          accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
+        },
+        5 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Jobs::SetStateToRunning, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        failure: -> (failure, previous) do
-          assert_equal(:invalid_state_transition, failure[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          failure: -> (failure, previous) do
+            assert_equal(:invalid_state_transition, failure[:type])
 
-          assert_equal({ invalid_state_transition: true }, failure[:result])
-        end,
-        accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
-      },
-    }.each do |index, transition_assertions|
-      transition_assertions.each do |key, assertion|
-        transition_scope = result2_transitions[index][key]
+            assert_equal({ invalid_state_transition: true }, failure[:result])
+          end,
+          accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
+        },
+      }.each do |index, transition_assertions|
+        transition_assertions.each do |key, assertion|
+          transition_scope = result2_transitions[index][key]
 
-        if assertion.arity == 1
-          assertion.call(transition_scope)
-        else
-          previous_transition = result2_transitions[index - 1] if index != 0
+          if assertion.arity == 1
+            assertion.call(transition_scope)
+          else
+            previous_transition = result2_transitions[index - 1] if index != 0
 
-          assertion.call(transition_scope, previous_transition)
+            assertion.call(transition_scope, previous_transition)
+          end
         end
       end
+    else
+      assert_equal([], result2_transitions)
     end
   end
 

--- a/test/micro/cases/safe/flow_test.rb
+++ b/test/micro/cases/safe/flow_test.rb
@@ -14,92 +14,96 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
 
     result1_transitions = result1.transitions
 
-    assert_equal(4, result1_transitions.size)
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(4, result1_transitions.size)
 
-    {
-      0 => {
-        use_case: -> use_case do
-          assert_equal(Safe::Jobs::State::FetchSleeping, use_case[:class])
+      {
+        0 => {
+          use_case: -> use_case do
+            assert_equal(Safe::Jobs::State::FetchSleeping, use_case[:class])
 
-          assert_equal({}, use_case[:attributes])
-        end,
-        success: -> success do
-          assert_equal(:ok, success[:type])
+            assert_equal({}, use_case[:attributes])
+          end,
+          success: -> success do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_nil(job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([], keys) }
-      },
-      1 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::SetID, use_case[:class])
+            assert_nil(job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([], keys) }
+        },
+        1 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::SetID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success) do
-          assert_equal(:ok, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success) do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      2 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::ValidateID, use_case[:class])
+            assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        2 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::ValidateID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) { assert_equal(previous[:success], success) },
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      3 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::SetStateToRunning, use_case[:class])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) { assert_equal(previous[:success], success) },
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        3 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::SetStateToRunning, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) do
-          assert_equal(:state_updated, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) do
+            assert_equal(:state_updated, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job, :changes], result.keys)
+            assert_equal([:job, :changes], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_equal(previous[:success][:result][:job].id, job.id)
-          assert_predicate(job, :running?)
+            assert_equal(previous[:success][:result][:job].id, job.id)
+            assert_predicate(job, :running?)
 
-          result[:changes].changed?(:state, from: 'sleeping', to: 'running')
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      }
-    }.each do |index, transition_assertions|
-      transition_assertions.each do |key, assertion|
-        transition_scope = result1_transitions[index][key]
+            result[:changes].changed?(:state, from: 'sleeping', to: 'running')
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        }
+      }.each do |index, transition_assertions|
+        transition_assertions.each do |key, assertion|
+          transition_scope = result1_transitions[index][key]
 
-        if assertion.arity == 1
-          assertion.call(transition_scope)
-        else
-          previous_transition = result1_transitions[index - 1] if index != 0
+          if assertion.arity == 1
+            assertion.call(transition_scope)
+          else
+            previous_transition = result1_transitions[index - 1] if index != 0
 
-          assertion.call(transition_scope, previous_transition)
+            assertion.call(transition_scope, previous_transition)
+          end
         end
       end
+    else
+      assert_equal([], result1_transitions)
     end
 
     # ---
@@ -112,126 +116,130 @@ class Micro::Cases::Safe::FlowTest < Minitest::Test
 
     result2_transitions = result2.transitions
 
-    assert_equal(6, result2_transitions.size)
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(6, result2_transitions.size)
 
-    {
-      0 => {
-        use_case: -> use_case do
-          assert_equal(Safe::Jobs::State::FetchSleeping, use_case[:class])
+      {
+        0 => {
+          use_case: -> use_case do
+            assert_equal(Safe::Jobs::State::FetchSleeping, use_case[:class])
 
-          assert_equal({}, use_case[:attributes])
-        end,
-        success: -> success do
-          assert_equal(:ok, success[:type])
+            assert_equal({}, use_case[:attributes])
+          end,
+          success: -> success do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_nil(job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([], keys) }
-      },
-      1 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::SetID, use_case[:class])
+            assert_nil(job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([], keys) }
+        },
+        1 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::SetID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success) do
-          assert_equal(:ok, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success) do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
-          assert_predicate(job, :sleeping?)
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      2 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::ValidateID, use_case[:class])
+            assert_match(%r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}, job.id)
+            assert_predicate(job, :sleeping?)
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        2 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::ValidateID, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) { assert_equal(previous[:success], success) },
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      3 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::SetStateToRunning, use_case[:class])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) { assert_equal(previous[:success], success) },
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        3 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::SetStateToRunning, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        success: -> (success, previous) do
-          assert_equal(:state_updated, success[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          success: -> (success, previous) do
+            assert_equal(:state_updated, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job, :changes], result.keys)
+            assert_equal([:job, :changes], result.keys)
 
-          job = result[:job]
+            job = result[:job]
 
-          assert_equal(previous[:success][:result][:job].id, job.id)
-          assert_predicate(job, :running?)
+            assert_equal(previous[:success][:result][:job].id, job.id)
+            assert_predicate(job, :running?)
 
-          result[:changes].changed?(:state, from: 'sleeping', to: 'running')
-        end,
-        accessible_attributes: -> keys { assert_equal([:job], keys) }
-      },
-      4 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::ValidateID, use_case[:class])
+            result[:changes].changed?(:state, from: 'sleeping', to: 'running')
+          end,
+          accessible_attributes: -> keys { assert_equal([:job], keys) }
+        },
+        4 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::ValidateID, use_case[:class])
 
-          attributes = use_case[:attributes]
+            attributes = use_case[:attributes]
 
-          assert_equal([:job], attributes.keys)
+            assert_equal([:job], attributes.keys)
 
-          assert_equal(previous[:success][:result][:job], attributes[:job])
-        end,
-        success: -> (success, previous) do
-          assert_equal(:ok, success[:type])
+            assert_equal(previous[:success][:result][:job], attributes[:job])
+          end,
+          success: -> (success, previous) do
+            assert_equal(:ok, success[:type])
 
-          result = success[:result]
+            result = success[:result]
 
-          assert_equal([:job], result.keys)
+            assert_equal([:job], result.keys)
 
-          assert_equal(previous[:success][:result][:job], result[:job])
-        end,
-        accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
-      },
-      5 => {
-        use_case: -> (use_case, previous) do
-          assert_equal(Safe::Jobs::SetStateToRunning, use_case[:class])
+            assert_equal(previous[:success][:result][:job], result[:job])
+          end,
+          accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
+        },
+        5 => {
+          use_case: -> (use_case, previous) do
+            assert_equal(Safe::Jobs::SetStateToRunning, use_case[:class])
 
-          assert_equal(previous[:success][:result], use_case[:attributes])
-        end,
-        failure: -> (failure, previous) do
-          assert_equal(:invalid_state_transition, failure[:type])
+            assert_equal(previous[:success][:result], use_case[:attributes])
+          end,
+          failure: -> (failure, previous) do
+            assert_equal(:invalid_state_transition, failure[:type])
 
-          assert_equal({ invalid_state_transition: true }, failure[:result])
-        end,
-        accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
-      },
-    }.each do |index, transition_assertions|
-      transition_assertions.each do |key, assertion|
-        transition_scope = result2_transitions[index][key]
+            assert_equal({ invalid_state_transition: true }, failure[:result])
+          end,
+          accessible_attributes: -> keys { assert_equal([:job, :changes], keys) }
+        },
+      }.each do |index, transition_assertions|
+        transition_assertions.each do |key, assertion|
+          transition_scope = result2_transitions[index][key]
 
-        if assertion.arity == 1
-          assertion.call(transition_scope)
-        else
-          previous_transition = result2_transitions[index - 1] if index != 0
+          if assertion.arity == 1
+            assertion.call(transition_scope)
+          else
+            previous_transition = result2_transitions[index - 1] if index != 0
 
-          assertion.call(transition_scope, previous_transition)
+            assertion.call(transition_scope, previous_transition)
+          end
         end
       end
+    else
+      assert_equal([], result2_transitions)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,10 +17,14 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'u-case'
 
-if ENV.fetch('ACTIVEMODEL_VERSION', '6.1.0') < '6.1.0'
-  Micro::Case.config do |config|
-    config.enable_activemodel_validation = true
-  end
+Micro::Case.config do |config|
+  enable_activemodel = ENV.fetch('ACTIVEMODEL_VERSION', '6.1.0') < '6.1.0'
+
+  config.enable_activemodel_validation = enable_activemodel
+
+  enable_transitions = ENV.fetch('ENABLE_TRANSITIONS', 'true') == 'true'
+
+  config.enable_transitions = enable_transitions
 end
 
 require 'minitest/pride'


### PR DESCRIPTION
- [x] Fix flow execution when transitions are disabled
- [x] Use double splat operator in internal steps that receive a method instance
- [x] Bump version to 3.0.0.rc8