### PR TITLE
Added Micro::Case #apply as an alias for #method

### DIFF
--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -142,6 +142,8 @@ module Micro
 
     private
 
+      alias apply method
+
       def call
         return __call_use_case_flow if __call_use_case_flow?
 

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -142,7 +142,9 @@ module Micro
 
     private
 
-      alias apply method
+      def apply(name)
+        method(name)
+      end
 
       def call
         return __call_use_case_flow if __call_use_case_flow?

--- a/test/micro/case/internal_steps/with_methods_test.rb
+++ b/test/micro/case/internal_steps/with_methods_test.rb
@@ -17,7 +17,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
     def call!
       validate_attributes
         .then(method(:sum_a_and_b))
-        .then(method(:add), number: 3)
+        .then(apply(:add), number: 3)
         .then(SumHalf)
     end
 
@@ -97,7 +97,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
     def call!
       validate_number
         .then(method(:normalize_number))
-        .then(method(:multiply_by_two))
+        .then(apply(:multiply_by_two))
     end
 
     private
@@ -128,7 +128,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
     def call!
       validate_attributes \
         | method(:sum_a_and_b) \
-        | method(:add) \
+        | apply(:add) \
         | SumHalf
     end
 
@@ -208,7 +208,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
     def call!
       validate_number \
         | method(:normalize_number) \
-        | method(:multiply_by_two)
+        | apply(:multiply_by_two)
     end
 
     private
@@ -239,7 +239,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
     def call!
       get_c
         .then(method(:get_d))
-        .then(method(:sum_a_b_c_d))
+        .then(apply(:sum_a_b_c_d))
         .then(SumHalf)
     end
 
@@ -307,7 +307,7 @@ class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
     def call!
       get_c \
         | method(:get_d) \
-        | method(:sum_a_b_c_d) \
+        | apply(:sum_a_b_c_d) \
         | SumHalf
     end
 


### PR DESCRIPTION
Following our discussion on the Telegram group chat, added `#apply` as an alias for `#method` when using a Case with private methods, like so:
```ruby
def call!
  normalize_params
    .then(method(:do_something))
    .then(apply(:something_else))
end
```