### PR TITLE
Freeze Micro::Case::Result#data

### DIFF
--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -143,7 +143,7 @@ module Micro
 
         @success, @type, @use_case = is_success, type, use_case
 
-        @data = FetchData.call(data)
+        @data = FetchData.call(data).freeze
 
         raise Micro::Case::Error::InvalidResult.new(is_success, type, use_case) unless @data
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,6 +50,7 @@ module MicroCaseAssertions
     value = options[:value] || :____skip____
 
     assert_kind_of_result(result)
+    assert_predicate(result.data, :frozen?)
     assert_equal(type, result.type) if type != :____skip____
     assert_equal(value, result.value) if value != :____skip____
   end


### PR DESCRIPTION
## What is the problem this PR solves?

The change of result data, this is a bad practice. e.g.
```ruby
result.on_success { |result| result.data[:number] += 10 }
```

And it is not the first time which I see somebody doing this and asking me if it is ok because the `Micro::Case::Result#data` isn't frozen by default. So, my proposal is to freeze it by default and cut this evil in the root. 

---

PS: This change won't affect the performance. Check out the benchmark below to see this.

![image](https://user-images.githubusercontent.com/305364/90396286-57105780-e06c-11ea-8034-03d2713ec962.png)

```ruby
# Warming up --------------------------------------
#                  foo   210.346k i/100ms
#         bar (frozen)   193.275k i/100ms
# Calculating -------------------------------------
#                  foo      2.102M (± 1.6%) i/s -     10.517M in   5.005292s
#         bar (frozen)      1.953M (± 1.1%) i/s -      9.857M in   5.046754s
# end

class Bar
  def initialize
    @bar = "bar_#{rand(10)}".freeze
  end
end

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.time = 5
  x.warmup = 2

  x.report('foo') { Foo.new }
  x.report('bar (frozen)') { Bar.new }
end
```
