### PR TITLE
Fix simplecov version for Ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,15 @@ if activemodel_version < '6.1.0'
   gem 'activesupport', activemodel, require: false
 end
 
+simplecov_version =
+  case RUBY_VERSION
+  when /\A2.[23]/ then '~> 0.17.1'
+  when /\A2.4/ then '~> 0.18.5'
+  else '~> 0.19'
+  end
+
 group :test do
   gem 'minitest', activemodel_version < '4.1' ? '~> 4.2' : '~> 5.0'
-
-  simplecov_version = RUBY_VERSION < '2.4.0' ? '~> 0.17.1' : '>= 0.18.5'
 
   gem 'simplecov', simplecov_version, require: false
 end


### PR DESCRIPTION
The latest version of simplecov requires `Ruby >= 2.5.0`.

![simplecov___RubyGems_org___your_community_gem_host](https://user-images.githubusercontent.com/305364/90393959-20384280-e068-11ea-9c23-627c98b942c8.png)
