### PR TITLE
Enable branch coverage on Ruby > 2.5

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@ require 'simplecov'
 
 SimpleCov.start do
   add_filter "/test/"
+
+  enable_coverage :branch if RUBY_VERSION >= '2.5.0'
 end
 
 if ENV.fetch('ACTIVEMODEL_VERSION', '6.1') < '4.1'


### PR DESCRIPTION
This config is only for Ruby > 2.5.

It gives you this nice output when some branches are not target by tests.

![image](https://user-images.githubusercontent.com/20938712/90469676-e3179300-e0ef-11ea-9507-1921507f0024.png)

![image](https://user-images.githubusercontent.com/20938712/90469754-06dad900-e0f0-11ea-8282-b2e6a84f41d3.png)
