### PR TITLE
Add Micro::Case::Result#to_sym

### DIFF
--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -36,6 +36,10 @@ module Micro
         [data, type]
       end
 
+      def to_sym
+        @__success ? :success : :failure
+      end
+
       def [](key)
         data[key]
       end

--- a/lib/micro/case/result/transitions.rb
+++ b/lib/micro/case/result/transitions.rb
@@ -5,11 +5,9 @@ module Micro
     class Result
       class Transitions
         MapEverything = -> (result, use_case_attributes) do
-          result_track = result.to_sym
-
           {
             use_case: { class: result.use_case.class, attributes: use_case_attributes },
-            result_track => { type: result.type, result: result.data },
+            result.to_sym => { type: result.type, result: result.data },
             accessible_attributes: result.accessible_attributes
           }
         end

--- a/lib/micro/case/result/transitions.rb
+++ b/lib/micro/case/result/transitions.rb
@@ -5,7 +5,7 @@ module Micro
     class Result
       class Transitions
         MapEverything = -> (result, use_case_attributes) do
-          result_track = result.success? ? :success : :failure
+          result_track = result.to_sym
 
           {
             use_case: { class: result.use_case.class, attributes: use_case_attributes },

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -23,6 +23,7 @@ class Micro::Case::ResultTest < Minitest::Test
     result = success_result(value: { a: 1, b: 2 }, type: :ok, use_case: use_case)
 
     assert_predicate(result, :success?)
+    assert_equal(:success, result.to_sym)
     assert_equal(1, result.value[:a])
 
     assert_same(use_case, result.use_case)
@@ -87,6 +88,7 @@ class Micro::Case::ResultTest < Minitest::Test
     refute_predicate(result, :success?)
     assert_predicate(result, :failure?)
 
+    assert_equal(:failure, result.to_sym)
     assert_equal(0, result.value[:a])
     assert_same(use_case, result.use_case)
 


### PR DESCRIPTION
Solves #82, adding `#to_sym`, its respective tests and replacing the ternary in `Micro::Case::Transitions`.