### PR TITLE
Add Micro::Case::Result#on_unknown hook

### DIFF
--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -25,6 +25,7 @@ module Micro
       def initialize(transitions_mapper = Transitions::MapEverything)
         @__accumulated_data = {}
         @__accessible_attributes = {}
+        @__is_unknown = false
 
         enable_transitions = @@transitions_enabled
 
@@ -73,6 +74,7 @@ module Micro
       end
 
       def on_success(expected_type = nil)
+        @__is_unknown = true
         return self unless __success_type?(expected_type)
 
         hook_data = expected_type.nil? ? self : data
@@ -83,6 +85,7 @@ module Micro
       end
 
       def on_failure(expected_type = nil)
+        @__is_unknown = true
         return self unless __failure_type?(expected_type)
 
         hook_data = expected_type.nil? ? self : data
@@ -100,6 +103,10 @@ module Micro
         end
 
         self
+      end
+
+      def on_unknown
+
       end
 
       def then(use_case = nil, attributes = nil, &block)

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -23,9 +23,9 @@ module Micro
       alias value data
 
       def initialize(transitions_mapper = Transitions::MapEverything)
+        @__is_unknown = true
         @__accumulated_data = {}
         @__accessible_attributes = {}
-        @__is_unknown = true
 
         enable_transitions = @@transitions_enabled
 

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -26,6 +26,7 @@ module Micro
         @__accumulated_data = {}
         @__accessible_attributes = {}
         @__is_unknown = true
+
         enable_transitions = @@transitions_enabled
 
         @__transitions = enable_transitions ? [] : Kind::Empty::ARRAY
@@ -79,6 +80,7 @@ module Micro
       def on_success(expected_type = nil)
         return self unless __success_type?(expected_type)
 
+        @__is_unknown = false
         hook_data = expected_type.nil? ? self : data
 
         yield(hook_data, @use_case)
@@ -89,6 +91,7 @@ module Micro
       def on_failure(expected_type = nil)
         return self unless __failure_type?(expected_type)
 
+        @__is_unknown = false
         hook_data = expected_type.nil? ? self : data
 
         yield(hook_data, @use_case)

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -25,8 +25,7 @@ module Micro
       def initialize(transitions_mapper = Transitions::MapEverything)
         @__accumulated_data = {}
         @__accessible_attributes = {}
-        @__is_unknown = false
-
+        @__is_unknown = true
         enable_transitions = @@transitions_enabled
 
         @__transitions = enable_transitions ? [] : Kind::Empty::ARRAY
@@ -69,12 +68,15 @@ module Micro
         !success?
       end
 
+      def unknown?
+        @__is_unknown
+      end
+
       def accessible_attributes
         @__accessible_attributes.keys
       end
 
       def on_success(expected_type = nil)
-        @__is_unknown = true
         return self unless __success_type?(expected_type)
 
         hook_data = expected_type.nil? ? self : data
@@ -85,7 +87,6 @@ module Micro
       end
 
       def on_failure(expected_type = nil)
-        @__is_unknown = true
         return self unless __failure_type?(expected_type)
 
         hook_data = expected_type.nil? ? self : data
@@ -106,7 +107,9 @@ module Micro
       end
 
       def on_unknown
+        return self unless unknown?
 
+        yield(self, @use_case)
       end
 
       def then(use_case = nil, attributes = nil, &block)

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -113,6 +113,8 @@ module Micro
         return self unless unknown?
 
         yield(self, @use_case)
+
+        self
       end
 
       def then(use_case = nil, attributes = nil, &block)

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -172,7 +172,7 @@ class Micro::Case::ResultTest < Minitest::Test
   def test_the_on_unknown_hook
     number = rand(1..1_000_000)
 
-    failure_result = failure_result(value: { number }, type: :not_mapped, use_case: Micro::Case.new({}))
+    failure_result = failure_result(value: { number: number }, type: :not_mapped, use_case: Micro::Case.new({}))
 
     failure_result
       .on_failure(:a)
@@ -180,13 +180,12 @@ class Micro::Case::ResultTest < Minitest::Test
 
     # ---
 
-    success_result = success_result(value: { number }, type: :not_mapped, use_case: Micro::Case.new({}))
+    success_result = success_result(value: { number: number }, type: :not_mapped, use_case: Micro::Case.new({}))
 
     success_result
       .on_success(:b)
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
-    assert_equal(1, success_counter)
   end
 
   def test_the_repeated_on_unknown_hook_exception

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -178,6 +178,7 @@ class Micro::Case::ResultTest < Minitest::Test
       .on_failure(:a)
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
+    assert_predicate(failure_result, :unknown?)
     # ---
 
     success_result = success_result(value: { number: number }, type: :not_mapped, use_case: Micro::Case.new({}))
@@ -186,6 +187,7 @@ class Micro::Case::ResultTest < Minitest::Test
       .on_success(:b)
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
+    assert_predicate(success_result, :unknown?)
   end
 
   def test_the_repeated_on_unknown_hook_exception
@@ -208,6 +210,7 @@ class Micro::Case::ResultTest < Minitest::Test
       .on_unknown { failure_counter += 1 }
 
     assert_equal(1, failure_counter)
+    refute_predicate(failure_result, :unknown?)
 
     # ---
 
@@ -219,6 +222,7 @@ class Micro::Case::ResultTest < Minitest::Test
       .on_unknown { success_counter += 1 }
 
     assert_equal(1, success_counter)
+    refute_predicate(failure_result, :unknown?)
   end
 
   def test_the_output_of_a_failure_hook_without_a_defined_type

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -179,6 +179,7 @@ class Micro::Case::ResultTest < Minitest::Test
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
     assert_predicate(failure_result, :unknown?)
+
     # ---
 
     success_result = success_result(value: { number: number }, type: :not_mapped, use_case: Micro::Case.new({}))
@@ -188,16 +189,6 @@ class Micro::Case::ResultTest < Minitest::Test
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
     assert_predicate(success_result, :unknown?)
-  end
-
-  def test_the_repeated_on_unknown_hook_exception
-    result = success_result(value: {}, type: :ok, use_case: Micro::Case.new({}))
-
-    assert_raises do 
-      result
-        .on_unknown
-        .on_unknown
-    end
   end
 
   def test_the_on_unknown_hook_exclusivity
@@ -223,6 +214,17 @@ class Micro::Case::ResultTest < Minitest::Test
 
     assert_equal(1, success_counter)
     refute_predicate(failure_result, :unknown?)
+
+    # ---
+
+    unknown_counter = 0
+    unknown_result = success_result(value: {}, type: :not_mapped, use_case: Micro::Case.new({}))
+
+    unknown_result
+      .on_unknown { unknown_counter += 1 }
+      .on_unknown { unknown_counter += 1 }
+
+    assert_equal(2, unknown_counter)
   end
 
   def test_the_output_of_a_failure_hook_without_a_defined_type

--- a/test/micro/case/result_test.rb
+++ b/test/micro/case/result_test.rb
@@ -175,7 +175,7 @@ class Micro::Case::ResultTest < Minitest::Test
     failure_result = failure_result(value: { number: number }, type: :not_mapped, use_case: Micro::Case.new({}))
 
     failure_result
-      .on_failure(:a)
+      .on_failure(:a) { raise }
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
     assert_predicate(failure_result, :unknown?)
@@ -185,7 +185,7 @@ class Micro::Case::ResultTest < Minitest::Test
     success_result = success_result(value: { number: number }, type: :not_mapped, use_case: Micro::Case.new({}))
 
     success_result
-      .on_success(:b)
+      .on_success(:b) { raise }
       .on_unknown { |data| assert_equal(number, data[:number]) }
 
     assert_predicate(success_result, :unknown?)


### PR DESCRIPTION
Implements issue #25, adding a `#on_unknown` hook, to be used to handle results that doesn't meet any `Success` or `Failure` 
hooks.

- [x] Tests
- [x] Implementation