### PR TITLE
Add `Micro::Case#Check`

### DIFF
--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -240,7 +240,7 @@ module Micro
       end
 
 
-      def Check(type = nil, result: nil, on: {})
+      def Check(type = nil, result: nil, on: Kind::Empty::HASH)
         result_key = type || :check
 
         if value

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -239,8 +239,28 @@ module Micro
         __get_result(false, value, type)
       end
 
+
+      def Check(type = nil, result: nil)
+        value = yield
+        final_result = result || value
+
+        if value
+          type ||= :check_ok
+
+          Success(type, result: { type => final_result })
+        else
+          type ||= :check_fail
+
+          Failure(type, result: { type => final_result })
+        end
+      end
+
       def __get_result(is_success, value, type)
         @__result.__set__(is_success, value, type, self)
+      end
+
+      def __result
+        @__result ||= Result.new
       end
 
       def transaction(adapter = :activerecord)

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -240,27 +240,22 @@ module Micro
       end
 
 
-      def Check(type = nil, result: nil)
-        value = yield
-        final_result = result || value
+      def Check(type = nil, result: nil, on: {})
+        result_key = type || :check
 
         if value
-          type ||= :check_ok
+          result = on[:success] || { result_key => true }
 
-          Success(type, result: { type => final_result })
+          Success(type || :ok, result: result)
         else
-          type ||= :check_fail
+          result = on[:failure] || { result_key => false }
 
-          Failure(type, result: { type => final_result })
+          Failure(type || :error, result: result)
         end
       end
 
       def __get_result(is_success, value, type)
         @__result.__set__(is_success, value, type, self)
-      end
-
-      def __result
-        @__result ||= Result.new
       end
 
       def transaction(adapter = :activerecord)

--- a/test/micro/case_test.rb
+++ b/test/micro/case_test.rb
@@ -150,4 +150,40 @@ class Micro::CaseTest < Minitest::Test
       Multiply.inspect
     )
   end
+
+  class IsTruthy < Micro::Case
+    attribute :value
+
+    def call!
+      Check(:value_is_truthy) { value }
+    end
+  end
+
+  def test_that_it_returns_a_success_result_on_truthy_values
+    result = IsTruthy.call(value: true)
+
+    assert_success_result(result, value: { value_is_truthy: true })
+
+    result = IsTruthy.call(value: 'true')
+    
+    assert_success_result(result, value: { value_is_truthy: 'true' })
+  end
+
+  class IsEven < Micro::Case
+    attributes :number
+
+    def call!
+      Check(result: number) { number.even? }
+    end
+  end
+
+  def test_that_it_can_define_the_result_value
+    result = IsEven.call(number: 2)
+
+    assert_success_result(result, value: { check_ok: 2 })
+
+    result = IsEven.call(number: 1)
+
+    assert_failure_result(result, value: { check_fail: 1 })
+  end
 end

--- a/test/micro/case_test.rb
+++ b/test/micro/case_test.rb
@@ -155,35 +155,62 @@ class Micro::CaseTest < Minitest::Test
     attribute :value
 
     def call!
-      Check(:value_is_truthy) { value }
+      Check(result: value)
     end
   end
 
-  def test_that_it_returns_a_success_result_on_truthy_values
+  def test_check_with_just_the_value
     result = IsTruthy.call(value: true)
 
-    assert_success_result(result, value: { value_is_truthy: true })
+    assert_success_result(result, value: { check: true })
 
     result = IsTruthy.call(value: 'true')
+
+    assert_success_result(result, value: { check: true })
+
+    result = IsTruthy.call(value: false)
     
-    assert_success_result(result, value: { value_is_truthy: 'true' })
+    assert_failure_result(result, value: { check: false })
+
+    result = IsTruthy.call(value: nil)
+    
+    assert_failure_result(result, value: { check: false })
   end
 
-  class IsEven < Micro::Case
-    attributes :number
+  class IsTruthyWithType < Micro::Case
+    attribute :value
 
     def call!
-      Check(result: number) { number.even? }
+      Check(:is_truthy, result: value)
     end
   end
 
-  def test_that_it_can_define_the_result_value
-    result = IsEven.call(number: 2)
 
-    assert_success_result(result, value: { check_ok: 2 })
+  def test_check_with_custom_type
+    result = IsTruthyWithType.call(value: true)
 
-    result = IsEven.call(number: 1)
+    assert_success_result(result, value: { is_truthy: true })
 
-    assert_failure_result(result, value: { check_fail: 1 })
+    result = IsTruthyWithType.call(value: false)
+
+    assert_failure_result(result, value: { is_truthy: false })
+  end
+
+  class IsTruthyWithCustomData < Micro::Case
+    attribute :value
+
+    def call!
+      Check(result: value, on: { success: { result: :yay }, failure: { result: :nay } })
+    end
+  end
+
+  def test_check_with_custom_data
+    result = IsTruthyWithCustomData.call(value: true)
+
+    assert_success_result(result, value: { result: :yay })
+
+    result = IsTruthyWithCustomData.call(value: false)
+
+    assert_failure_result(result, value: { result: :nay })
   end
 end


### PR DESCRIPTION
This PR adds the method `Check` on Micro::Case.

## Micro::Case#Check

Check is a method that make simple to evaluate boolean conditions and turn them into `Result` objects.

Let's take this simple use case as an example. It should check if a given number is even and fails on odd numbers:

```ruby
  class IsEven  < Micro::Case
    attributes :number

    def call!
      if number.even?
        Success(result: { number_is_even: true } )
      else
        Failure(result: { number_is_even: false } )
      end
    end
  end
```

We can simplify this conditional by using `Check`. Take a look:

```ruby
  class IsEven < Micro::Case
    attributes :number

    def call!
      Check { number.even? }
    end
  end
```

### Changing the result type

It's possible to add a type a custom result type:

```ruby
  class IsEven < Micro::Case
    attributes :number

    def call!
      Check(:number_is_even) { number.even? }
    end
  end
```

### Changing the result value

By default `Check` adds the return of the given block as the Result value. In the example above, the value would be the result of `number.even?`.

You can define a custom return value with the `result:` keyword argument:

```ruby
  class IsEven < Micro::Case
    attributes :number

    def call!
      Check(:number_is_even, result: number) { number.even? }
    end
  end
```

In the example above, the result value will be `number`, rather than `number.even?`.

### Check with private methods

`Check` really shines when using private methods to define steps in a use case:

```ruby
  class IsEven < Micro::Case
    attributes :number

    def call!
      check_number_is_an_integer
        .then(method(:check_number_is_even))
    end

    private

    def check_number_is_an_integer
      Check(:number_is_integer) { number.is_a? Integer }
    end

    def check_number_is_even
      Check(:number_is_even) { number.even? }
    end
  end
```