### PR TITLE
Add `Micro::Case.Try`

### DIFF
--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -240,7 +240,7 @@ module Micro
       end
 
 
-      def Try(type = nil, catch: StandardError, on: {})
+      def Try(type = nil, catch: StandardError, on: Kind::Empty::HASH)
         result_key = type || :try
         block_value = yield
         result = on[:success] || { result_key => block_value }

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -239,6 +239,19 @@ module Micro
         __get_result(false, value, type)
       end
 
+
+      def Try(type = nil, catch: StandardError, on: {})
+        result_key = type || :try
+        block_value = yield
+        result = on[:success] || { result_key => block_value }
+
+        Success(type || :ok, result: result)
+      rescue *catch => e
+        result = on[:failure] || { result_key => e }
+
+        Failure(type || :exception, result: result)
+      end
+
       def __get_result(is_success, value, type)
         @__result.__set__(is_success, value, type, self)
       end

--- a/test/micro/case_test.rb
+++ b/test/micro/case_test.rb
@@ -173,7 +173,7 @@ class Micro::CaseTest < Minitest::Test
     result = Bomb.call(defused: false)
 
     assert_failure_result(result, type: :exception)
-    assert result.value[:try].is_a? RuntimeError
+    assert_kind_of(RuntimeError, result[:try])
   end
 
   class BombWithType < Micro::Case
@@ -199,7 +199,7 @@ class Micro::CaseTest < Minitest::Test
     result = BombWithType.call(defused: false)
 
     assert_failure_result(result, type: :defused)
-    assert(result.value[:defused].is_a? RuntimeError)
+    assert_kind_of(RuntimeError, result[:defused])
   end
 
   class Divide2 < Micro::Case
@@ -220,12 +220,12 @@ class Micro::CaseTest < Minitest::Test
     result = Divide2.call(a: 1 , b: 0)
 
     assert_failure_result(result)
-    assert(result.value[:try].is_a? ZeroDivisionError)
+    assert_kind_of(ZeroDivisionError, result[:try])
 
     result = Divide2.call(a: 1 , b: '0')
 
     assert_failure_result(result)
-    assert(result.value[:try].is_a? TypeError)
+    assert_kind_of(TypeError, result[:try])
 
 
     assert_raises NoMethodError do


### PR DESCRIPTION
Similar to #87, but for Exceptions.

I tried to follow kinda the same api for `Check`, but I'm open to suggestions.

```ruby
class Bomb < Micro::Case
  attributes :defused

  def call!
    Try do
      if defused
        :yay
      else
        raise 'Boooom!'
      end
    end
  end
end

Bomb.call(defused: true)
# => #<Success (Micro::Case::Result) type=:ok data={:try=>:yay} transitions=1>

Bomb.call(defused: false)
# => #<Failure (Micro::Case::Result) type=:exception data={:try=>#<RuntimeError: Boooom!>} transitions=1>
```

Check the tests for more details on usage.