### PR TITLE
Test against ActiveRecord 6.1.0

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -38,6 +38,10 @@ if [[ $ruby_v =~ '2.5.' ]] || [[ $ruby_v =~ '2.6.' ]] || [[ $ruby_v =~ '2.7.' ]]
   ACTIVERECORD_VERSION='6.0' bundle update
   ACTIVERECORD_VERSION='6.0' ENABLE_TRANSITIONS='true' bundle exec rake test
   ACTIVERECORD_VERSION='6.0' ENABLE_TRANSITIONS='false' bundle exec rake test
+
+  ACTIVERECORD_VERSION='6.1' bundle update
+  ACTIVERECORD_VERSION='6.1' ENABLE_TRANSITIONS='true' bundle exec rake test
+  ACTIVERECORD_VERSION='6.1' ENABLE_TRANSITIONS='false' bundle exec rake test
 fi
 
 bundle update

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-activerecord_version = ENV.fetch('ACTIVERECORD_VERSION', '6.1')
+activerecord_version = ENV.fetch('ACTIVERECORD_VERSION', '6.2')
 
 activerecord = case activerecord_version
               when '3.2' then '3.2.22'
@@ -13,6 +13,7 @@ activerecord = case activerecord_version
               when '5.1' then '5.1.7'
               when '5.2' then '5.2.3'
               when '6.0' then '6.0.3'
+              when '6.1' then '6.1.0'
               end
 
 simplecov_version =
@@ -30,7 +31,7 @@ group :test do
   if activerecord
     sqlite3 =
       case activerecord
-      when /\A6\.0/, nil then '~> 1.4.0'
+      when /\A6\.(0|1)/, nil then '~> 1.4.0'
       else '~> 1.3.0'
       end
 

--- a/test/micro/case/transaction/activerecord_test.rb
+++ b/test/micro/case/transaction/activerecord_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require 'active_record'
   require 'sqlite3'
 

--- a/test/micro/case/with_activemodel_validation/MWRF/steps/01_test.rb
+++ b/test/micro/case/with_activemodel_validation/MWRF/steps/01_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require_relative '../users_entity'
   require_relative '../shared_assertions'
 

--- a/test/micro/case/with_activemodel_validation/MWRF/steps/02_test.rb
+++ b/test/micro/case/with_activemodel_validation/MWRF/steps/02_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require_relative '../users_entity'
   require_relative '../shared_assertions'
 

--- a/test/micro/case/with_activemodel_validation/MWRF/steps/03_test.rb
+++ b/test/micro/case/with_activemodel_validation/MWRF/steps/03_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require_relative '../users_entity'
   require_relative '../shared_assertions'
 

--- a/test/micro/case/with_activemodel_validation/MWRF/steps/04_using_static_composition_test.rb
+++ b/test/micro/case/with_activemodel_validation/MWRF/steps/04_using_static_composition_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require_relative '../users_entity'
   require_relative '../shared_assertions'
 

--- a/test/micro/case/with_activemodel_validation/MWRF/steps/04_using_static_composition_via_inner_flow_test.rb
+++ b/test/micro/case/with_activemodel_validation/MWRF/steps/04_using_static_composition_via_inner_flow_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require_relative '../users_entity'
   require_relative '../shared_assertions'
 

--- a/test/micro/case/with_activemodel_validation/MWRF/steps/04_using_variable_composition_test.rb
+++ b/test/micro/case/with_activemodel_validation/MWRF/steps/04_using_variable_composition_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
   require_relative '../users_entity'
   require_relative '../shared_assertions'
 

--- a/test/micro/case/with_activemodel_validation/base_test.rb
+++ b/test/micro/case/with_activemodel_validation/base_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation
     class BaseTest < Minitest::Test

--- a/test/micro/case/with_activemodel_validation/classes_with_flows/all_steps_with_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/classes_with_flows/all_steps_with_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation::Safe
     module ClassesWithFlows

--- a/test/micro/case/with_activemodel_validation/classes_with_flows/first_step_with_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/classes_with_flows/first_step_with_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation::Safe
     module ClassesWithFlows

--- a/test/micro/case/with_activemodel_validation/classes_with_flows/last_step_with_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/classes_with_flows/last_step_with_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation::Safe
     module ClassesWithFlows

--- a/test/micro/case/with_activemodel_validation/config_test.rb
+++ b/test/micro/case/with_activemodel_validation/config_test.rb
@@ -22,7 +22,7 @@ module Micro::Case::WithActivemodelValidation
       )
     end
 
-    if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+    if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
       class Multiply < Micro::Case
         attribute :a
         attribute :b

--- a/test/micro/case/with_activemodel_validation/disable_auto_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/disable_auto_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation
     class DisableAutoValidationTest < Minitest::Test

--- a/test/micro/case/with_activemodel_validation/safe/base_test.rb
+++ b/test/micro/case/with_activemodel_validation/safe/base_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation::Safe
     class BaseTest < Minitest::Test

--- a/test/micro/case/with_activemodel_validation/safe/classes_with_flows/all_steps_with_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/safe/classes_with_flows/all_steps_with_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation
     module ClassesWithFlows

--- a/test/micro/case/with_activemodel_validation/safe/classes_with_flows/first_step_with_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/safe/classes_with_flows/first_step_with_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation
     module ClassesWithFlows

--- a/test/micro/case/with_activemodel_validation/safe/classes_with_flows/last_step_with_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/safe/classes_with_flows/last_step_with_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation
     module ClassesWithFlows

--- a/test/micro/case/with_activemodel_validation/safe/disable_auto_validation_test.rb
+++ b/test/micro/case/with_activemodel_validation/safe/disable_auto_validation_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation::Safe
     class DisableAutoValidationTest < Minitest::Test

--- a/test/micro/case/with_activemodel_validation/safe/strict_test.rb
+++ b/test/micro/case/with_activemodel_validation/safe/strict_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation::Safe
     class StrictTest < Minitest::Test

--- a/test/micro/case/with_activemodel_validation/strict_test.rb
+++ b/test/micro/case/with_activemodel_validation/strict_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-if ENV.fetch('ACTIVERECORD_VERSION', '6.1') <= '6.0.0'
+if ENV.fetch('ACTIVERECORD_VERSION', '6.2') <= '6.1.0'
 
   module Micro::Case::WithActivemodelValidation
     class StrictTest < Minitest::Test


### PR DESCRIPTION
I don't know if this is being worked on, but I noticed that u-case is not being tested on ActiveRecord 6.1.0 (Ruby >= 2.5.0), so this PR include testing on it.