### PR TITLE
Refactors #then to allow passing symbols as well

### DIFF
--- a/test/micro/case/internal_steps/with_symbols_test.rb
+++ b/test/micro/case/internal_steps/with_symbols_test.rb
@@ -1,0 +1,376 @@
+require 'test_helper'
+
+class Micro::Case::InternalStepsWithMethodsTest < Minitest::Test
+  class SumHalf < Micro::Case
+    attribute :sum
+
+    def call!
+      Success :third_sum, result: {
+        sum: sum + 0.5
+      }
+    end
+  end
+
+  class DoSomeSumUsingThenWithMethods < Micro::Case
+    attributes :a, :b
+
+    def call!
+      validate_attributes
+        .then(:sum_a_and_b)
+        .then(:add, number: 3)
+        .then(SumHalf)
+    end
+
+    private
+
+      def validate_attributes
+        Kind.of?(Numeric, a, b) ? Success(:valid) : Failure()
+      end
+
+      def sum_a_and_b
+        Success :first_sum, result: { sum: a + b }
+      end
+
+      def add(sum:, number:, **)
+        Success :second_sum, result: { sum: sum + number }
+      end
+  end
+
+  def test_the_then_method_with_symbol_instances
+    resulta = DoSomeSumUsingThenWithMethods.call(a: 1, b: 2)
+
+    assert_success_result(resulta, value: { sum: 6.5 })
+
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
+          success: { type: :valid, result: { valid: true } },
+          accessible_attributes: [:a, :b]
+        },
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
+          success: { type: :first_sum, result: { sum: 3 } },
+          accessible_attributes: [:a, :b, :valid]
+        },
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: 2 } },
+          success: { type: :second_sum, result: { sum: 6 } },
+          accessible_attributes: [:a, :b, :valid, :number, :sum]
+        },
+        {
+          use_case: { class: SumHalf, attributes: { sum: 6 } },
+          success: { type: :third_sum, result: { sum: 6.5 } },
+          accessible_attributes: [:a, :b, :valid, :number, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resulta.transitions[index])
+      end
+    else
+      assert_equal([], resulta.transitions)
+    end
+
+    # ---
+
+    resultb = DoSomeSumUsingThenWithMethods.call(a: 1, b: '2')
+
+    assert_failure_result(resultb, value: { error: true })
+
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingThenWithMethods, attributes: { a: 1, b: '2' } },
+          failure: { type: :error, result: { error: true } },
+          accessible_attributes: [:a, :b]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resultb.transitions[index])
+      end
+    else
+      assert_equal([], resultb.transitions)
+    end
+  end
+
+  
+
+  class MultiplyByTwoUsingThenWithMethods < Micro::Case
+    attributes :number
+
+    def call!
+      validate_number
+        .then(:normalize_number)
+        .then(:multiply_by_two)
+    end
+
+    private
+
+    def validate_number
+      Kind.of?(Numeric, number) ? Success(:valid) : Failure()
+    end
+
+    def normalize_number
+      { normalized_number: number.to_f }
+    end
+
+    def multiply_by_two(number)
+      Success(result: { number: number * 2 })
+    end
+  end
+
+  def test_the_then_method_error_when_a_method_instance_doesnt_return_a_result
+    assert_raises_with_message(
+      Micro::Case::Error::UnexpectedResult,
+      /MultiplyByTwoUsingThenWithMethods#method\(:normalize_number\) must return an instance of Micro::Case::Result/
+    ) { MultiplyByTwoUsingThenWithMethods.call(number: 2) }
+  end
+
+  class DoSomeSumUsingPipeWithMethods < Micro::Case
+    attributes :a, :b
+    attribute :number, default: 4
+
+    def call!
+      validate_attributes \
+        | (:sum_a_and_b) \
+        | (:add) \
+        | SumHalf
+    end
+
+    private
+
+      def validate_attributes
+        Kind.of?(Numeric, a, b) ? Success(:valid) : Failure()
+      end
+
+      def sum_a_and_b
+        Success :first_sum, result: { sum: a + b }
+      end
+
+      def add(sum:, **)
+        Success :second_sum, result: { sum: sum + number }
+      end
+  end
+
+  def test_the_pipe_method_with_method_instances
+    resulta = DoSomeSumUsingPipeWithMethods.call(a: 1, b: 2)
+
+    assert_success_result(resulta, value: { sum: 7.5 })
+
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
+          success: { type: :valid, result: { valid: true } },
+          accessible_attributes: [:a, :b, :number]
+        },
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
+          success: { type: :first_sum, result: { sum: 3 } },
+          accessible_attributes: [:a, :b, :number, :valid]
+        },
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: 2, number: 4 } },
+          success: { type: :second_sum, result: { sum: 7 } },
+          accessible_attributes: [:a, :b, :number, :valid, :sum]
+        },
+        {
+          use_case: { class: SumHalf, attributes: { sum: 7 } },
+          success: { type: :third_sum, result: { sum: 7.5 } },
+          accessible_attributes: [:a, :b, :number, :valid, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resulta.transitions[index])
+      end
+    else
+      assert_equal([], resulta.transitions)
+    end
+
+    # ---
+
+    resultb = DoSomeSumUsingPipeWithMethods.call(a: 1, b: '2')
+
+    assert_failure_result(resultb, value: { error: true })
+
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: { class: DoSomeSumUsingPipeWithMethods, attributes: { a: 1, b: '2', number: 4 } },
+          failure: { type: :error, result: { error: true } },
+          accessible_attributes: [:a, :b, :number]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, resultb.transitions[index])
+      end
+    else
+      assert_equal([], resultb.transitions)
+    end
+  end
+
+  class MultiplyByTwoUsingPipeWithMethods < Micro::Case
+    attributes :number
+
+    def call!
+      validate_number \
+        | :normalize_number \
+        | :multiply_by_two
+    end
+
+    private
+
+    def validate_number
+      Kind.of?(Numeric, number) ? Success(:valid) : Failure()
+    end
+
+    def normalize_number
+      { normalized_number: number.to_f }
+    end
+
+    def multiply_by_two(normalized_number:, **)
+      Success(result: { number: normalized_number * 2 })
+    end
+  end
+
+  def test_the_pipe_method_error_when_a_method_instance_doesnt_return_a_result
+    assert_raises_with_message(
+      Micro::Case::Error::UnexpectedResult,
+      /MultiplyByTwoUsingPipeWithMethods#method\(:normalize_number\) must return an instance of Micro::Case::Result/
+    ) { MultiplyByTwoUsingPipeWithMethods.call(number: 2) }
+  end
+
+  class DoSomeCalcUsingThenWithMethods < Micro::Case
+    attributes :a, :b
+
+    def call!
+      get_c
+        .then(:get_d)
+        .then(:sum_a_b_c_d)
+        .then(SumHalf)
+    end
+
+    private
+
+    def get_c
+      Success :c, result: { c: 3 }
+    end
+
+    def get_d
+      Success :d, result: { d: 4 }
+    end
+
+    def sum_a_b_c_d(c:, d:, **)
+      Success :sum_a_b_c_d, result: { sum: a + b + c + d }
+    end
+  end
+
+  def test_the_data_accumulation_through_the_then_method
+    result = DoSomeCalcUsingThenWithMethods.call(a: 1, b: 2)
+
+    assert_success_result(result, value: { sum: 10.5 })
+
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+          },
+          success: {type: :c, result: { c: 3 }},
+          accessible_attributes: [:a, :b]
+        },
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2 }
+          },
+          success: { type: :d, result: { d: 4 }},
+          accessible_attributes: [:a, :b, :c]
+        },
+        {
+          use_case: {
+            class: DoSomeCalcUsingThenWithMethods, attributes: { a: 1, b: 2}
+          },
+          success: { type: :sum_a_b_c_d, result: { sum: 10 }},
+          accessible_attributes: [:a, :b, :c, :d]
+        },
+        {
+          use_case: {
+            class: SumHalf, attributes: { sum: 10 }
+          },
+          success: { type: :third_sum, result: { sum: 10.5 }},
+          accessible_attributes: [:a, :b, :c, :d, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, result.transitions[index])
+      end
+    else
+      assert_equal([], result.transitions)
+    end
+  end
+
+  class DoSomeCalcUsingPipeWithMethods < Micro::Case
+    attributes :a, :b
+
+    def call!
+      get_c \
+        | (:get_d) \
+        | (:sum_a_b_c_d) \
+        | SumHalf
+    end
+
+    private
+
+    def get_c
+      Success :c, result: { c: 3 }
+    end
+
+    def get_d
+      Success :d, result: { d: 4 }
+    end
+
+    def sum_a_b_c_d(data)
+      c, d = data.fetch(:c), data.fetch(:d)
+
+      Success :sum_a_b_c_d, result: { sum: a + b + c + d }
+    end
+  end
+
+  def test_the_data_accumulation_through_the_pipe_method
+    result = DoSomeCalcUsingPipeWithMethods.call(a: 2, b: 2)
+
+    assert_success_result(result, value: { sum: 11.5 })
+
+    if ::Micro::Case::Result.transitions_enabled?
+      [
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+          },
+          success: {type: :c, result: { c: 3 }},
+          accessible_attributes: [:a, :b]
+        },
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2 }
+          },
+          success: { type: :d, result: { d: 4 }},
+          accessible_attributes: [:a, :b, :c]
+        },
+        {
+          use_case: {
+            class: DoSomeCalcUsingPipeWithMethods, attributes: { a: 2, b: 2}
+          },
+          success: { type: :sum_a_b_c_d, result: { sum: 11 }},
+          accessible_attributes: [:a, :b, :c, :d]
+        },
+        {
+          use_case: {
+            class: SumHalf, attributes: { sum: 11 }
+          },
+          success: { type: :third_sum, result: { sum: 11.5 }},
+          accessible_attributes: [:a, :b, :c, :d, :sum]
+        }
+      ].each_with_index do |transition, index|
+        assert_equal(transition, result.transitions[index])
+      end
+    else
+      assert_equal([], result.transitions)
+    end
+  end
+end


### PR DESCRIPTION
Implements the enhancement mentioned in #118 

Allows #then method to also receive symbols and strings with the name of the methods.
Ex:

```
normalize_params
    .then(:sanitize)
    .then(:validate)
    .then(:persist)
```

The advantage of having the option to pass symbols/strings as arguments to #then is that it makes it more straighforward for the user to call subsequent methods on the result object chain. Thus the responsibility to convert the symbol into a method object (by using metaprogramming `method` or an use case alias like `apply`) is now on the use case class, instead of the client. 
At the same time, it is still allowed to pass method objects directly, just as procs, as it was allowed previously, so it doesn't break the api. 
As #| (pipe) is basically  #then with some small modifications, then it also allows symbols and strings with this PR.