### PR TITLE
respond_to? renamed into utils.rb to avoid overriding default one

### DIFF
--- a/lib/micro/case/utils.rb
+++ b/lib/micro/case/utils.rb
@@ -3,12 +3,12 @@
 module Micro::Case::Utils
 
   module Hashes
-    def self.respond_to?(hash, method)
+    def self.hash_respond_to?(hash, method)
       Kind::Hash[hash].respond_to?(method)
     end
 
     def self.symbolize_keys(hash)
-      return hash.transform_keys { |key| key.to_sym rescue key } if respond_to?(hash, :transform_keys)
+      return hash.transform_keys { |key| key.to_sym rescue key } if hash_respond_to?(hash, :transform_keys)
 
       hash.each_with_object({}) do |(k, v), memo|
         key = k.to_sym rescue k
@@ -17,13 +17,13 @@ module Micro::Case::Utils
     end
 
     def self.stringify_keys(hash)
-      return hash.transform_keys(&:to_s) if respond_to?(hash, :transform_keys)
+      return hash.transform_keys(&:to_s) if hash_respond_to?(hash, :transform_keys)
 
       hash.each_with_object({}) { |(k, v), memo| memo[k.to_s] = v }
     end
 
     def self.slice(hash, keys)
-      return hash.slice(*keys) if respond_to?(hash, :slice)
+      return hash.slice(*keys) if hash_respond_to?(hash, :slice)
 
       hash.select { |key, _value| keys.include?(key) }
     end


### PR DESCRIPTION
Since version 1.4.3 (https://github.com/ruby/irb/compare/v1.4.3...master), irb ruby gem (https://github.com/ruby/irb) is calling directly "respond_to?" method on all included code inside a project. That change makes all code included in a project having that method crashing if implementing that method in a non-standard way, like described in the ruby doc: https://www.rubydoc.info/stdlib/core/Object:respond_to%3F

So, I just wanted to propose that simple method renaming (very open to other names) to prevent overriding the default respond_to? Ruby implementation one, having here another signature and another usage.