### PR TITLE
Harden CI workflow per zizmor findings (permissions, persist-credentials)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }} (transitions=${{ matrix.transitions }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +22,8 @@ jobs:
       ENABLE_TRANSITIONS: ${{ matrix.transitions }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary
Address two of the three zizmor findings Qlty surfaced on the CI workflow:

- **`zizmor/excessive-permissions` (Medium)** — declare an explicit least-privilege `permissions: { contents: read }` on the test job, so the GITHUB_TOKEN scope no longer depends on repo defaults.
- **`zizmor/artipacked` (Medium)** — set `persist-credentials: false` on `actions/checkout@v4`. Defense in depth: prevents the token being written to `.git/config`, which can otherwise leak via uploaded artifacts.

The third finding (`zizmor/unpinned-uses`, High — `actions/checkout@v4`, `ruby/setup-ruby@v1`, `qltysh/qlty-action/coverage@v2` use mutable tag refs) is intentionally **not** addressed in this PR: solid-process keeps the same tag-pin convention, and SHA-pinning is best tackled across both gems together with Dependabot.

## Test plan
- [ ] CI matrix stays green (no behavioral change expected; this only narrows token scope)
- [ ] On next qlty rescan after merge, findings #2 and #3 drop off

🤖 Generated with [Claude Code](https://claude.com/claude-code)