### PR TITLE
Flow composition matrix + fix Result propagation through class-level inner flows

### DIFF
--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -232,7 +232,7 @@ module Micro
       end
 
       def __call_the_use_case_flow
-        self.class.__flow_get__.call(@__input)
+        self.class.__flow_get__.call!(input: @__input, result: @__result)
       end
 
       def Success(type = :ok, result: nil)

--- a/test/micro/cases/flow/composition_chaining_test.rb
+++ b/test/micro/cases/flow/composition_chaining_test.rb
@@ -1,0 +1,199 @@
+require 'test_helper'
+require 'support/composition_steps'
+
+# Result#then is a first-class way to compose flows in u-case: a use case
+# or flow can be chained onto an existing Result at runtime, optionally with
+# default attributes. Class.then/Flow.then are class-level convenience that
+# desugar to .call.then(...).
+#
+# This file exhaustively crosses the chaining surface with the four flow
+# constructors so that state accumulation across mixed compositions is
+# guaranteed even when the chain is built dynamically.
+class Micro::Cases::Flow::CompositionChainingTest < Minitest::Test
+  include CompositionSteps
+
+  # ---------------------------------------------------------------------------
+  # Result#then onto every wrapper-built segment.
+  # ---------------------------------------------------------------------------
+  WRAPPERS.each_key do |wrapper_name|
+    define_method("test_result_then_chains_a_step_onto_#{wrapper_name}") do
+      flow = WRAPPERS.fetch(wrapper_name).call([A, B, C, D])
+
+      result = flow.call(INPUT).then(E)
+
+      assert_predicate(result, :success?)
+      assert_equal(%w[A B C D E], result.data[:log])
+      assert_equal(5, result.data[:counter])
+      assert_equal('E', result.data[:e_marker])
+    end
+  end
+
+  WRAPPERS.each_key do |wrapper_name|
+    define_method("test_result_then_chains_a_subflow_onto_#{wrapper_name}") do
+      head = WRAPPERS.fetch(wrapper_name).call([A, B])
+      tail = WRAPPERS.fetch(wrapper_name).call([C, D, E])
+
+      result = head.call(INPUT).then(tail)
+
+      assert_predicate(result, :success?)
+      assert_equal(%w[A B C D E], result.data[:log])
+      assert_equal(5, result.data[:counter])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # 4-level composition built exclusively via Result#then.
+  # ---------------------------------------------------------------------------
+  def test_four_levels_of_composition_via_result_then_only
+    result =
+      A.call(**INPUT)
+        .then(B)
+        .then(C)
+        .then(D)
+        .then(E)
+
+    assert_predicate(result, :success?)
+    assert_equal(%w[A B C D E], result.data[:log])
+    assert_equal(5, result.data[:counter])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Mixing wrappers and chaining: build a wrapper-based 2-level flow, then
+  # extend it with two more steps using #then to reach 4+ composition levels.
+  # ---------------------------------------------------------------------------
+  WRAPPERS.each_key do |w1|
+    WRAPPERS.each_key do |w2|
+      define_method("test_mixed_chain_#{w1}__#{w2}__then__then") do
+        inner = WRAPPERS.fetch(w1).call([A, B])
+        outer = WRAPPERS.fetch(w2).call([inner, C])
+
+        result = outer.call(INPUT).then(D).then(E)
+
+        assert_predicate(result, :success?)
+        assert_equal(%w[A B C D E], result.data[:log])
+        assert_equal(5, result.data[:counter])
+        %i[a_marker b_marker c_marker d_marker].each do |key|
+          assert_includes(result.accessible_attributes, key)
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Class.then / Flow.then class-level chaining. These desugar to
+  # `self.call.then(other)`, so the head must be callable with no args. We
+  # use a head that exposes default values via the input arity-zero call path
+  # by going through the explicit .call(INPUT) when needed.
+  # ---------------------------------------------------------------------------
+  def test_flow_then_chains_a_step_class_level
+    # Cases::Flow#then is the public API the README documents.
+    head = Micro::Cases.flow([CompositionInit, A, B])
+    chained = head.then(C)
+
+    assert_predicate(chained, :success?)
+    assert_equal(%w[A B C], chained.data[:log])
+    assert_equal(3, chained.data[:counter])
+  end
+
+  # A leaf with default values so it can be invoked through `Class.then`.
+  class CompositionInit < Micro::Case
+    attribute :log,     default: []
+    attribute :counter, default: 0
+
+    def call!
+      Success result: { log: log, counter: counter }
+    end
+  end
+
+  def test_use_case_class_then_chains_a_step
+    # Use-case class-level then; head is a Micro::Case with default attrs so
+    # that `self.call` works without arguments.
+    chained = CompositionInit.then(A).then(B).then(C).then(D).then(E)
+
+    assert_predicate(chained, :success?)
+    assert_equal(%w[A B C D E], chained.data[:log])
+    assert_equal(5, chained.data[:counter])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Dependency injection via Result#then(use_case, defaults).
+  # ---------------------------------------------------------------------------
+  class Tag < Micro::Case::Strict
+    attributes :log, :counter, :a_marker, :b_marker, :tag
+
+    def call!
+      Success result: {
+        log: log + ["tag=#{tag}"],
+        counter: counter + 1,
+        tag: tag
+      }
+    end
+  end
+
+  WRAPPERS.each_key do |wrapper_name|
+    define_method("test_result_then_with_defaults_after_#{wrapper_name}") do
+      flow = WRAPPERS.fetch(wrapper_name).call([A, B])
+
+      result = flow.call(INPUT).then(Tag, tag: 'X')
+
+      assert_predicate(result, :success?)
+      assert_equal(['A', 'B', 'tag=X'], result.data[:log])
+      assert_equal(3, result.data[:counter])
+      assert_equal('X', result.data[:tag])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Failure short-circuits the .then chain.
+  # ---------------------------------------------------------------------------
+  def test_result_then_short_circuits_on_failure
+    result =
+      A.call(**INPUT)
+        .then(Fail)
+        .then(B)   # never reached
+        .then(C)   # never reached
+
+    assert_predicate(result, :failure?)
+    assert_equal(:step_failed, result.type)
+    assert_equal(%w[A Fail], result.data[:log])
+    assert_equal(2, result.data[:counter])
+    assert_instance_of(Fail, result.use_case)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Transitions: every step participated in via #then must appear exactly
+  # once in result.transitions.
+  # ---------------------------------------------------------------------------
+  if ::Micro::Case::Result.transitions_enabled?
+    def test_result_then_appends_one_transition_per_step
+      result =
+        A.call(**INPUT)
+          .then(B)
+          .then(C)
+          .then(D)
+          .then(E)
+
+      assert_equal(
+        [A, B, C, D, E],
+        result.transitions.map { |t| t[:use_case][:class] }
+      )
+    end
+
+    WRAPPERS.each_key do |wrapper_name|
+      define_method("test_result_then_with_subflow_built_by_#{wrapper_name}_keeps_one_transition_per_leaf") do
+        head = WRAPPERS.fetch(wrapper_name).call([A, B])
+        tail = WRAPPERS.fetch(wrapper_name).call([C, D, E])
+
+        result = head.call(INPUT).then(tail)
+
+        transition_classes = result.transitions.map { |t| t[:use_case][:class] }
+
+        assert_equal(
+          [A, B, C, D, E],
+          transition_classes,
+          "expected one transition per leaf step when chaining a #{wrapper_name} subflow"
+        )
+      end
+    end
+  end
+end

--- a/test/micro/cases/flow/composition_matrix_test.rb
+++ b/test/micro/cases/flow/composition_matrix_test.rb
@@ -1,0 +1,211 @@
+require 'test_helper'
+require 'support/composition_steps'
+
+# Exhaustively exercises every supported way of composing flows in u-case
+# and verifies that state is always accumulated across the entire chain,
+# regardless of how deep or mixed the composition is.
+#
+# Composition forms (wrappers) exercised:
+#
+#   * Micro::Cases.flow([...])
+#   * Micro::Cases.safe_flow([...])
+#   * class < Micro::Case;       flow(...) end
+#   * class < Micro::Case::Safe; flow(...) end
+#
+# Each test starts from {log: [], counter: 0} and expects the canonical
+# A -> B -> C -> D -> E chain to leave behind:
+#
+#   * log     == ["A","B","C","D","E"]
+#   * counter == 5
+#   * E's marker key in result.data
+#   * every prior step's marker key in result.accessible_attributes
+class Micro::Cases::Flow::CompositionMatrixTest < Minitest::Test
+  include CompositionSteps
+
+  STEPS = [A, B, C, D, E].freeze
+
+  def assert_full_chain_accumulation(result)
+    assert_kind_of(Micro::Case::Result, result)
+    assert_predicate(result, :success?)
+
+    data = result.data
+    assert_equal(%w[A B C D E], data[:log], "log not accumulated across chain")
+    assert_equal(5, data[:counter], "counter not accumulated across chain")
+    assert_equal('E', data[:e_marker])
+
+    # accessible_attributes tracks attributes that were passed *into* a use
+    # case. The final step's brand-new output keys are reachable through
+    # result.data; the earlier markers must be available on every step that
+    # follows the one which produced them.
+    %i[log counter a_marker b_marker c_marker d_marker].each do |key|
+      assert_includes(
+        result.accessible_attributes, key,
+        "expected :#{key} to be in accessible_attributes after the full chain"
+      )
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Level 1: each wrapper used standalone with the full 5-step chain.
+  # ---------------------------------------------------------------------------
+  WRAPPERS.each_key do |wrapper_name|
+    define_method("test_level_1_#{wrapper_name}_accumulates_state") do
+      flow = WRAPPERS.fetch(wrapper_name).call(STEPS)
+
+      result = flow.call(INPUT)
+
+      assert_full_chain_accumulation(result)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Level 2 pair matrix: every wrapper inside every wrapper, with the inner
+  # holding [A, B] and the outer holding [<inner>, C, D, E].
+  # ---------------------------------------------------------------------------
+  WRAPPERS.each_key do |outer_name|
+    WRAPPERS.each_key do |inner_name|
+      define_method("test_level_2_outer_#{outer_name}_inner_#{inner_name}") do
+        inner = WRAPPERS.fetch(inner_name).call([A, B])
+        outer = WRAPPERS.fetch(outer_name).call([inner, C, D, E])
+
+        result = outer.call(INPUT)
+
+        assert_full_chain_accumulation(result)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Full 4-level matrix: 4 wrappers ^ 4 levels = 256 combinations.
+  #
+  #   L1 wraps [A, B]
+  #   L2 wraps [L1, C]
+  #   L3 wraps [L2, D]
+  #   L4 wraps [L3, E]
+  #
+  # Every combination must execute A -> B -> C -> D -> E and accumulate state.
+  # ---------------------------------------------------------------------------
+  WRAPPERS.each_key do |w1|
+    WRAPPERS.each_key do |w2|
+      WRAPPERS.each_key do |w3|
+        WRAPPERS.each_key do |w4|
+          method_name = "test_level_4_#{w1}__#{w2}__#{w3}__#{w4}"
+
+          define_method(method_name) do
+            l1 = WRAPPERS.fetch(w1).call([A, B])
+            l2 = WRAPPERS.fetch(w2).call([l1, C])
+            l3 = WRAPPERS.fetch(w3).call([l2, D])
+            l4 = WRAPPERS.fetch(w4).call([l3, E])
+
+            result = l4.call(INPUT)
+
+            assert_full_chain_accumulation(result)
+          end
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Failure propagation: a failing step short-circuits the chain regardless
+  # of where in the nesting it sits.
+  # ---------------------------------------------------------------------------
+  WRAPPERS.each_key do |wrapper_name|
+    define_method("test_failure_short_circuit_in_#{wrapper_name}") do
+      flow = WRAPPERS.fetch(wrapper_name).call([A, Fail, B, C])
+
+      result = flow.call(INPUT)
+
+      assert_predicate(result, :failure?)
+      assert_equal(:step_failed, result.type)
+      assert_equal(%w[A Fail], result.data[:log])
+      assert_equal(2, result.data[:counter])
+      assert_instance_of(Fail, result.use_case)
+    end
+  end
+
+  def test_failure_short_circuit_in_deep_nesting
+    WRAPPERS.each_key do |w1|
+      WRAPPERS.each_key do |w4|
+        l1 = WRAPPERS.fetch(w1).call([A, Fail])
+        l2 = WRAPPERS.fetch(w1).call([l1, B])
+        l3 = WRAPPERS.fetch(w4).call([l2, C])
+        l4 = WRAPPERS.fetch(w4).call([l3, D])
+
+        result = l4.call(INPUT)
+
+        assert_predicate(result, :failure?, "expected failure for #{w1}/#{w4}")
+        assert_equal(:step_failed, result.type)
+        assert_instance_of(Fail, result.use_case)
+        assert_equal(%w[A Fail], result.data[:log])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Safe wrappers must rescue exceptions raised by a leaf step, anywhere in
+  # the chain, and surface them as :exception failures.
+  # ---------------------------------------------------------------------------
+  %i[cases_safe_flow safe_class_flow].each do |safe_wrapper|
+    define_method("test_safe_wrapper_#{safe_wrapper}_rescues_exception_at_level_1") do
+      flow = WRAPPERS.fetch(safe_wrapper).call([A, Boom, B])
+
+      result = flow.call(INPUT)
+
+      assert_predicate(result, :failure?)
+      assert_equal(:exception, result.type)
+      assert_kind_of(BoomError, result.data[:exception])
+    end
+  end
+
+  def test_safe_wrapper_rescues_exception_in_deeply_nested_chain
+    %i[cases_safe_flow safe_class_flow].each do |outer_safe|
+      %i[cases_safe_flow safe_class_flow].each do |inner_safe|
+        inner = WRAPPERS.fetch(inner_safe).call([A, Boom])
+        outer = WRAPPERS.fetch(outer_safe).call([inner, B, C])
+
+        result = outer.call(INPUT)
+
+        assert_predicate(result, :failure?, "expected failure for #{outer_safe}/#{inner_safe}")
+        assert_equal(:exception, result.type)
+        assert_kind_of(BoomError, result.data[:exception])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Transitions: every successful step in the chain must produce exactly one
+  # transition entry in the final result, even when the chain spans 4 levels
+  # of mixed wrappers.
+  # ---------------------------------------------------------------------------
+  if ::Micro::Case::Result.transitions_enabled?
+    WRAPPERS.each_key do |w1|
+      WRAPPERS.each_key do |w2|
+        WRAPPERS.each_key do |w3|
+          WRAPPERS.each_key do |w4|
+            method_name = "test_transitions_count_4_levels_#{w1}__#{w2}__#{w3}__#{w4}"
+
+            define_method(method_name) do
+              l1 = WRAPPERS.fetch(w1).call([A, B])
+              l2 = WRAPPERS.fetch(w2).call([l1, C])
+              l3 = WRAPPERS.fetch(w3).call([l2, D])
+              l4 = WRAPPERS.fetch(w4).call([l3, E])
+
+              result = l4.call(INPUT)
+
+              assert_predicate(result, :success?)
+
+              transition_classes = result.transitions.map { |t| t[:use_case][:class] }
+
+              assert_equal(
+                [A, B, C, D, E],
+                transition_classes,
+                "expected one transition per leaf step in #{w1}/#{w2}/#{w3}/#{w4}, got #{transition_classes.inspect}"
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/micro/cases/flow/composition_state_test.rb
+++ b/test/micro/cases/flow/composition_state_test.rb
@@ -1,0 +1,210 @@
+require 'test_helper'
+require 'support/composition_steps'
+
+# Explicit, transition-by-transition verification that the accumulated state
+# (log, counter, and accessible_attributes) is propagated correctly through
+# every nesting level of every composition form, including the dependency
+# injection step shape ([UseCase, defaults_hash]) and self-referential inner
+# flows.
+class Micro::Cases::Flow::CompositionStateTest < Minitest::Test
+  include CompositionSteps
+
+  def deepest_4_level_flow
+    # All four wrappers combined in one chain, each level adding one step on
+    # top of the previous. Equivalent runtime chain: A -> B -> C -> D -> E.
+    l1 = WRAPPERS.fetch(:cases_flow).call([A, B])
+    l2 = WRAPPERS.fetch(:class_flow).call([l1, C])
+    l3 = WRAPPERS.fetch(:cases_safe_flow).call([l2, D])
+    WRAPPERS.fetch(:safe_class_flow).call([l3, E])
+  end
+
+  def test_state_is_visible_to_every_step_in_a_4_level_mixed_chain
+    result = deepest_4_level_flow.call(INPUT)
+
+    assert_predicate(result, :success?)
+    assert_equal(%w[A B C D E], result.data[:log])
+    assert_equal(5, result.data[:counter])
+
+    return unless ::Micro::Case::Result.transitions_enabled?
+
+    transitions = result.transitions
+
+    assert_equal([A, B, C, D, E], transitions.map { |t| t[:use_case][:class] })
+
+    # Each step's input must include every marker produced by previous steps.
+    expected_markers_in_input = {
+      A => [],
+      B => [:a_marker],
+      C => [:a_marker, :b_marker],
+      D => [:a_marker, :b_marker, :c_marker],
+      E => [:a_marker, :b_marker, :c_marker, :d_marker]
+    }
+
+    transitions.each do |transition|
+      step_class = transition[:use_case][:class]
+      input_keys = transition[:use_case][:attributes].keys
+
+      expected_markers_in_input.fetch(step_class).each do |marker|
+        assert_includes(
+          input_keys, marker,
+          "#{step_class} did not receive #{marker.inspect} as input"
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Dependency injection via [UseCase, defaults_hash] step shape.
+  # ---------------------------------------------------------------------------
+  class Increment < Micro::Case
+    attributes :log, :counter, :by
+
+    def call!
+      Success result: {
+        log: log + ["+#{by}"],
+        counter: counter + by
+      }
+    end
+  end
+
+  def test_dependency_injection_step_shape_in_a_nested_flow
+    inner = Micro::Cases.flow([
+      A,
+      [Increment, by: 10]
+    ])
+
+    outer = Micro::Cases.flow([
+      inner,
+      [Increment, by: 5],
+      B
+    ])
+
+    result = outer.call(INPUT)
+
+    assert_predicate(result, :success?)
+    assert_equal(['A', '+10', '+5', 'B'], result.data[:log])
+    assert_equal(17, result.data[:counter]) # 1 (A) + 10 + 5 + 1 (B)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Self-referential inner flow: a use case that includes itself as a step.
+  # Both `self` and `self.call!` should produce equivalent inner Self steps.
+  # ---------------------------------------------------------------------------
+  class SelfReferentialViaSelf < Micro::Case
+    flow CompositionSteps::A, self, CompositionSteps::B
+
+    attributes :log, :counter, :a_marker
+
+    def call!
+      Success result: {
+        log: log + ['Self'],
+        counter: counter + 100,
+        a_marker: a_marker
+      }
+    end
+  end
+
+  class SelfReferentialViaSelfCallBang < Micro::Case
+    flow CompositionSteps::A, self.call!, CompositionSteps::B
+
+    attributes :log, :counter, :a_marker
+
+    def call!
+      Success result: {
+        log: log + ['SelfBang'],
+        counter: counter + 100,
+        a_marker: a_marker
+      }
+    end
+  end
+
+  def test_self_referential_inner_flow_via_self_accumulates_state
+    result = SelfReferentialViaSelf.call(**INPUT)
+
+    assert_predicate(result, :success?)
+    assert_equal(['A', 'Self', 'B'], result.data[:log])
+    assert_equal(102, result.data[:counter]) # 1 (A) + 100 (Self) + 1 (B)
+
+    return unless ::Micro::Case::Result.transitions_enabled?
+
+    classes = result.transitions.map { |t| t[:use_case][:class] }
+    assert_equal([A, SelfReferentialViaSelf::Self, B], classes)
+  end
+
+  def test_self_referential_inner_flow_via_self_call_bang_accumulates_state
+    result = SelfReferentialViaSelfCallBang.call(**INPUT)
+
+    assert_predicate(result, :success?)
+    assert_equal(['A', 'SelfBang', 'B'], result.data[:log])
+    assert_equal(102, result.data[:counter])
+
+    return unless ::Micro::Case::Result.transitions_enabled?
+
+    classes = result.transitions.map { |t| t[:use_case][:class] }
+    assert_equal([A, SelfReferentialViaSelfCallBang::Self, B], classes)
+  end
+
+  # Combine a self-referential class with the matrix wrappers to ensure
+  # transitions propagate when the self-referential class is itself nested
+  # inside outer flows.
+  def test_self_referential_class_nested_inside_each_wrapper_preserves_transitions
+    WRAPPERS.each do |wrapper_name, wrapper|
+      flow = wrapper.call([SelfReferentialViaSelf, C, D])
+
+      result = flow.call(INPUT)
+
+      assert_predicate(result, :success?, "expected success for #{wrapper_name}")
+      assert_equal(['A', 'Self', 'B', 'C', 'D'], result.data[:log])
+
+      next unless ::Micro::Case::Result.transitions_enabled?
+
+      classes = result.transitions.map { |t| t[:use_case][:class] }
+
+      assert_equal(
+        [A, SelfReferentialViaSelf::Self, B, C, D],
+        classes,
+        "expected all leaf steps to appear in transitions when nested in #{wrapper_name}"
+      )
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Cases.flow flattens a Flow instance passed as a step, but a class with an
+  # inner flow is kept opaque. The fix to __call_the_use_case_flow guarantees
+  # both shapes accumulate state identically.
+  # ---------------------------------------------------------------------------
+  def test_flow_instance_step_is_flattened_at_build_time
+    inner = Micro::Cases.flow([A, B])
+    outer = Micro::Cases.flow([inner, C])
+
+    assert_equal([A, B, C], outer.use_cases)
+  end
+
+  def test_class_with_inner_flow_step_is_kept_opaque
+    inner_class = WRAPPERS.fetch(:class_flow).call([A, B])
+    outer = Micro::Cases.flow([inner_class, C])
+
+    assert_equal([inner_class, C], outer.use_cases)
+  end
+
+  def test_both_step_shapes_produce_identical_runtime_behaviour
+    inner_flow_instance = Micro::Cases.flow([A, B])
+    inner_via_class = WRAPPERS.fetch(:class_flow).call([A, B])
+
+    out_via_instance = Micro::Cases.flow([inner_flow_instance, C, D, E])
+    out_via_class    = Micro::Cases.flow([inner_via_class,    C, D, E])
+
+    r1 = out_via_instance.call(INPUT)
+    r2 = out_via_class.call(INPUT)
+
+    assert_equal(r1.data, r2.data, "flattened and opaque nesting must produce identical data")
+
+    if ::Micro::Case::Result.transitions_enabled?
+      assert_equal(
+        r1.transitions.map { |t| t[:use_case][:class] },
+        r2.transitions.map { |t| t[:use_case][:class] },
+        "flattened and opaque nesting must produce identical transitions"
+      )
+    end
+  end
+end

--- a/test/support/composition_steps.rb
+++ b/test/support/composition_steps.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# Leaf use cases used by the flow composition matrix tests.
+#
+# Each step appends its identifier to a shared :log array and increments a
+# shared :counter. Strict subclasses require the markers produced by all
+# previous steps in the canonical A -> B -> C -> D -> E chain, which forces
+# the flow machinery to keep the accumulated state visible to every step
+# regardless of how deep the composition is nested.
+module CompositionSteps
+  class A < Micro::Case
+    attributes :log, :counter
+
+    def call!
+      Success result: {
+        log: log + ['A'],
+        counter: counter + 1,
+        a_marker: 'A'
+      }
+    end
+  end
+
+  class B < Micro::Case::Strict
+    attributes :log, :counter, :a_marker
+
+    def call!
+      Success result: {
+        log: log + ['B'],
+        counter: counter + 1,
+        b_marker: 'B'
+      }
+    end
+  end
+
+  class C < Micro::Case::Safe
+    attributes :log, :counter, :a_marker, :b_marker
+
+    def call!
+      Success result: {
+        log: log + ['C'],
+        counter: counter + 1,
+        c_marker: 'C'
+      }
+    end
+  end
+
+  class D < Micro::Case::Strict::Safe
+    attributes :log, :counter, :a_marker, :b_marker, :c_marker
+
+    def call!
+      Success result: {
+        log: log + ['D'],
+        counter: counter + 1,
+        d_marker: 'D'
+      }
+    end
+  end
+
+  class E < Micro::Case::Strict
+    attributes :log, :counter, :a_marker, :b_marker, :c_marker, :d_marker
+
+    def call!
+      Success result: {
+        log: log + ['E'],
+        counter: counter + 1,
+        e_marker: 'E'
+      }
+    end
+  end
+
+  # Always fails with a known type.
+  class Fail < Micro::Case
+    attributes :log, :counter
+
+    def call!
+      Failure :step_failed, result: {
+        log: log + ['Fail'],
+        counter: counter + 1,
+        reason: 'forced failure'
+      }
+    end
+  end
+
+  # Custom exception so it isn't classified as "wrong usage" by
+  # Micro::Case::Error.by_wrong_usage? (ArgumentError, Kind::Error,
+  # InvalidResult and UnexpectedResult are intentionally re-raised even
+  # inside Safe wrappers).
+  class BoomError < StandardError; end
+
+  # Raises an exception; only Safe wrappers can rescue it.
+  class Boom < Micro::Case
+    attributes :log, :counter
+
+    def call!
+      raise BoomError, 'boom!'
+    end
+  end
+
+  INPUT = { log: [], counter: 0 }.freeze
+
+  WRAPPERS = {
+    cases_flow:      ->(steps) { Micro::Cases.flow(steps) },
+    cases_safe_flow: ->(steps) { Micro::Cases.safe_flow(steps) },
+    class_flow:      ->(steps) {
+      Class.new(Micro::Case) { flow(steps) }
+    },
+    safe_class_flow: ->(steps) {
+      Class.new(Micro::Case::Safe) { flow(steps) }
+    }
+  }.freeze
+end


### PR DESCRIPTION
## Summary

- Adds an exhaustive test matrix that crosses **every supported way of composing flows** in u-case and asserts that the `Micro::Case::Result` always accumulates state through the entire chain — regardless of nesting depth, the constructors used at each level, or whether the chain was extended later via `Result#then`.
- Fixes a latent state-loss bug in `Micro::Case#__call_the_use_case_flow`: invoking a class with an inner `flow ...` definition created a **fresh** `Micro::Case::Result` instead of extending the parent one, dropping transitions and accumulated data whenever a class-with-flow was nested inside another flow or chained via `Result#then`.

## Composition forms exercised by the matrix

| Form | Example |
| --- | --- |
| Module-level | `Micro::Cases.flow([...])` |
| Module-level (safe) | `Micro::Cases.safe_flow([...])` |
| Inner flow (regular) | `class < Micro::Case; flow ...; end` |
| Inner flow (safe) | `class < Micro::Case::Safe; flow ...; end` |
| Dynamic chaining | `result.then(use_case_or_flow[, defaults])` |
| Class/flow `.then` | `UseCase.then(other)` / `Flow.then(other)` |
| DI step shape | `[UseCase, defaults_hash]` |
| Self-referential | `flow A, self, B` / `flow A, self.call!, B` |

For the four primary constructors, the suite builds a 4-level deep composition for every combination (4⁴ = 256) of the canonical `A -> B -> C -> D -> E` chain and asserts:

- The accumulated `:log` and `:counter` reflect every step in order.
- Every prior step's marker is visible in `result.accessible_attributes`.
- The full chain produces exactly one transition per leaf step in the correct order.
- A failing step short-circuits the chain at any nesting level.
- `Safe` wrappers rescue arbitrary exceptions (anything not classified as wrong-usage) at any nesting level.

## The fix

`Micro::Case#__call_the_use_case_flow` previously invoked the class-level inner flow with:

```ruby
self.class.__flow_get__.call(@__input)
```

`Cases::Flow#call` always builds a fresh `Result.new`, so any transitions already on the parent result were thrown away. The fix routes through `Cases::Flow#call!`, reusing the parent `@__result`:

```ruby
self.class.__flow_get__.call!(input: @__input, result: @__result)
```

This unifies behavior across the four flow constructors and is what made it possible for the matrix transitions assertions to hold for every combination — most visibly the chaining cases where the head was a `Cases::Flow` instance and the tail was a class-with-flow (and vice versa).

## Test plan

- [x] `bundle exec rake test` — 724 runs, 8007 assertions, 0 failures, 0 errors.
- [x] All 256 4-level matrix combinations pass (state + transitions).
- [x] Failure short-circuit verified at every nesting level.
- [x] `Safe` wrappers rescue `BoomError` (a non-wrong-usage exception) at every nesting level.
- [x] `Result#then` / class-level `.then` / `[UseCase, defaults]` / self-referential `self` and `self.call!` covered.
- [x] Pre-existing 139 tests untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)