### PR TITLE
Add ruby-lsp as a development gem on Ruby >= 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,7 @@ end
 group :development, :test do
   gem "awesome_print"
 end
+
+group :development do
+  gem "ruby-lsp", require: false if RUBY_VERSION >= "3.0"
+end


### PR DESCRIPTION
## Summary

- Adds `ruby-lsp` to the Gemfile under the `:development` group, gated on `RUBY_VERSION >= "3.0"`.
- The gem only supports modern Rubies, so older interpreters in the CI matrix simply skip it.
- Loaded with `require: false` since it is editor tooling, not used at runtime.

## Test plan

- [x] `bundle install` resolves cleanly and pulls `ruby-lsp` (verified locally).
- [x] `Gemfile.lock` is git-ignored, so no lockfile churn lands in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)