### PR TITLE
5.5.0: Add results contract to enforce declared Success/Failure shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `Micro::Case.results { |on| ... }` macro to declare a results contract — the allowed `Success`/`Failure` types and the result keys each one requires. `Success(...)` / `Failure(...)` calls that use an undeclared type now raise `Micro::Case::Error::UnexpectedResultType`; calls missing a declared required key raise `Micro::Case::Error::MissingResultKeys`. Use cases without a `results` block keep their previous unrestricted behavior. Rescued exceptions in `Micro::Case::Safe` are not subject to the contract. The check routes through `Micro::Case::Check#results_contract!`, so it is also bypassed when `config.disable_runtime_checks = true` (closes #22).
+- `Micro::Case.results { |on| ... }` macro to declare a results contract — the allowed `Success`/`Failure` types and the result keys each one requires. `Success(...)` / `Failure(...)` calls that use an undeclared type now raise `Micro::Case::Error::UnexpectedResultType`; calls missing a declared required key raise `Micro::Case::Error::MissingResultKeys`. Use cases without a `results` block keep their previous unrestricted behavior. The check routes through `Micro::Case::Check#results_contract!`, so it is also bypassed when `config.disable_runtime_checks = true` (closes #22). Carve-outs so contracts don't break neighbouring features:
+  - Framework-generated `__failure_from_attributes_errors` (the auto-failure produced when `accept:`/`reject:` or ActiveModel validation rejects an input) bypasses the contract — it goes directly to `__set__` rather than through `Failure(...)` — so combining `results` with attribute validation no longer requires declaring `:invalid_attributes`.
+  - Rescued exceptions in `Micro::Case::Safe` (which produce `Failure(result: exception)`) bypass the contract.
+  - Result hashes with `String` keys are matched against the contract's symbolised required keys — `Success(result: { 'value' => 1 })` satisfies `result: [:value]`, mirroring `Result`'s own tolerance for either key type.
+  - Non-`Hash` / non-`Symbol` `result:` arguments fall through to the existing `Micro::Case::Error::InvalidResult` ("must be a Hash") instead of being misreported as missing keys.
+  - Non-`Symbol` `type` arguments fall through to `Micro::Case::Error::InvalidResultType` instead of being misreported as undeclared.
+  - `Micro::Case.results` raises `ArgumentError` when called on the abstract base class itself, so a stray declaration cannot leak a contract to every subclass in the process.
 
 ## [5.4.0] - 2026-05-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note:** This gem was originally published as `u-service` (versions 0.1.0 – 1.0.0) and renamed to `u-case` starting with `u-case 1.0.0` on 2019-09-15.
 
+## [Unreleased]
+### Added
+- `Micro::Case.results { |on| ... }` macro to declare a results contract — the allowed `Success`/`Failure` types and the result keys each one requires. `Success(...)` / `Failure(...)` calls that use an undeclared type now raise `Micro::Case::Error::UnexpectedResultType`; calls missing a declared required key raise `Micro::Case::Error::MissingResultKeys`. Use cases without a `results` block keep their previous unrestricted behavior. Rescued exceptions in `Micro::Case::Safe` are not subject to the contract. The check routes through `Micro::Case::Check#results_contract!`, so it is also bypassed when `config.disable_runtime_checks = true` (closes #22).
+
 ## [5.4.0] - 2026-05-24
 ### Added
 - `Micro::Case.config.disable_runtime_checks` config (default `false`) to skip the gem's internal argument/contract checks for better performance in production. All checks are consolidated in `Micro::Case::Check::Enabled` (the default) and `Micro::Case::Check::Disabled` (no-ops with the same signature); the active module is swapped via `Micro::Case.check`. Measured throughput win is JIT-dependent: within noise on stock Ruby (no JIT), ~3–5% on Ruby 3.2 +YJIT, ~4–7% on Ruby 4.0 +PRISM (see `benchmarks/perfomance/runtime_checks/compare.rb`). Closes #45.
@@ -468,6 +472,7 @@ First release under the `u-case` name (renamed from `u-service`).
 - `Micro::Service::Result` with `Success`/`Failure` factories and helper methods for returning typed results from services.
 - Runtime dependency on `u-attributes` for service input declaration.
 
+[Unreleased]: https://github.com/serradura/u-case/compare/v5.4.0...HEAD
 [5.4.0]: https://github.com/serradura/u-case/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/serradura/u-case/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/serradura/u-case/compare/v5.2.1...v5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note:** This gem was originally published as `u-service` (versions 0.1.0 – 1.0.0) and renamed to `u-case` starting with `u-case 1.0.0` on 2019-09-15.
 
-## [Unreleased]
+## [5.5.0] - 2026-05-24
 ### Added
 - `Micro::Case.results { |on| ... }` macro to declare a results contract — the allowed `Success`/`Failure` types and the result keys each one requires. `Success(...)` / `Failure(...)` calls that use an undeclared type now raise `Micro::Case::Error::UnexpectedResultType`; calls missing a declared required key raise `Micro::Case::Error::MissingResultKeys`. Use cases without a `results` block keep their previous unrestricted behavior. The check routes through `Micro::Case::Check#results_contract!`, so it is also bypassed when `config.disable_runtime_checks = true` (closes #22). Carve-outs so contracts don't break neighbouring features:
   - Framework-generated `__failure_from_attributes_errors` (the auto-failure produced when `accept:`/`reject:` or ActiveModel validation rejects an input) bypasses the contract — it goes directly to `__set__` rather than through `Failure(...)` — so combining `results` with attribute validation no longer requires declaring `:invalid_attributes`.
@@ -478,7 +478,7 @@ First release under the `u-case` name (renamed from `u-service`).
 - `Micro::Service::Result` with `Success`/`Failure` factories and helper methods for returning typed results from services.
 - Runtime dependency on `u-attributes` for service input declaration.
 
-[Unreleased]: https://github.com/serradura/u-case/compare/v5.4.0...HEAD
+[5.5.0]: https://github.com/serradura/u-case/compare/v5.4.0...v5.5.0
 [5.4.0]: https://github.com/serradura/u-case/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/serradura/u-case/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/serradura/u-case/compare/v5.2.1...v5.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,17 @@ Both files are user-facing — keep them in sync with the code:
 - **`README.md` and `README.pt-BR.md`**: the **Documentation** table and the
   **Compatibility** table at the top reference the latest released version
   and its dependency bounds. Update both files together — they are
-  translations of each other and must stay in lockstep. If you change a
-  documented API, update both READMEs in the same commit.
+  translations of each other and must stay in lockstep. Any user-visible
+  API change requires a README update in the same commit:
+  - **New public API** (new macro, new module-level method, new public
+    instance method, new error class users can rescue, new config option) —
+    add or extend the relevant section in both READMEs with an example.
+  - **Changed documented API** — update the existing section in both
+    READMEs to match the new behavior.
+  - **Removed/deprecated API** — remove or mark the section in both
+    READMEs.
+  - Pure internal refactors, CI tweaks, and test-only changes don't need
+    README updates.
 
 ## Internal argument checks live in `Micro::Case::Check`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The main project goals are:
 Version   | Documentation
 --------- | -------------
 unreleased| https://github.com/serradura/u-case/blob/main/README.md
-5.4.0     | https://github.com/serradura/u-case/blob/v5.x/README.md
+5.5.0     | https://github.com/serradura/u-case/blob/v5.x/README.md
 4.5.1     | https://github.com/serradura/u-case/blob/v4.x/README.md
 
 > **Note:** Você entende português? 🇧🇷&nbsp;🇵🇹 Verifique o [README traduzido em pt-BR](https://github.com/serradura/u-case/blob/main/README.pt-BR.md).
@@ -91,7 +91,7 @@ unreleased| https://github.com/serradura/u-case/blob/main/README.md
 | u-case           | branch | ruby     | activemodel    | u-attributes   |
 | ---------------- | ------ | -------- | -------------- | -------------- |
 | unreleased       | main   | >= 2.7   | >= 6.0         | >= 2.8, < 4.0  |
-| 5.4.0            | v5.x   | >= 2.7   | >= 6.0         | >= 2.8, < 4.0  |
+| 5.5.0            | v5.x   | >= 2.7   | >= 6.0         | >= 2.8, < 4.0  |
 | 5.1.0            | v5.x   | >= 2.7   | >= 6.0         | >= 2.7, < 4.0  |
 | 4.5.1            | v4.x   | >= 2.2.0 | >= 3.2, <= 8.1 | >= 2.7, < 3.0  |
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ unreleased| https://github.com/serradura/u-case/blob/main/README.md
     - [What are the default result types?](#what-are-the-default-result-types)
     - [How to define custom result types?](#how-to-define-custom-result-types)
     - [Is it possible to define a custom type without a result data?](#is-it-possible-to-define-a-custom-type-without-a-result-data)
+    - [How to declare a results contract?](#how-to-declare-a-results-contract)
     - [How to use the result hooks?](#how-to-use-the-result-hooks)
     - [Why the hook usage without a defined type exposes the result itself?](#why-the-hook-usage-without-a-defined-type-exposes-the-result-itself)
       - [Using decomposition to access the result data and type](#using-decomposition-to-access-the-result-data-and-type)
@@ -332,6 +333,58 @@ result.use_case.attributes # {"a"=>2, "b"=>"2"}
 # This feature is handy to handle failures in a flow
 # (this topic will be covered ahead).
 ```
+
+[⬆️ Back to Top](#table-of-contents-)
+
+#### How to declare a results contract?
+
+Answer: Use the `results do |on| ... end` macro to declare which result types your use case can return, and which keys each one requires. When a contract is declared, `Success(...)` / `Failure(...)` calls that use an undeclared type raise `Micro::Case::Error::UnexpectedResultType`, and calls that omit a declared required key raise `Micro::Case::Error::MissingResultKeys`.
+
+```ruby
+class Divide < Micro::Case
+  attributes :a, :b
+
+  results do |on|
+    on.failure(:attributes_must_be_numbers)
+    on.failure(:division_by_zero)
+
+    on.success(result: [:division])
+  end
+
+  def call!
+    return Failure(:attributes_must_be_numbers) unless Kind.of?(Numeric, a, b)
+    return Failure(:division_by_zero) if b == 0
+
+    Success result: { division: a / b }
+  end
+end
+
+Divide.call(a: 10, b: 2).data # => { division: 5 }
+Divide.call(a: 10, b: 0).type # => :division_by_zero
+Divide.call(a: 'x', b: 2).type # => :attributes_must_be_numbers
+```
+
+A type passed to `on.success` / `on.failure` without a `result:` argument declares the type with no required keys (any payload — including the implicit `{ type => true }` from `Failure(:my_type)` — is accepted). When `result: [:key1, :key2]` is given, those keys must be present in the result hash; extra keys are allowed.
+
+```ruby
+class Wrong < Micro::Case
+  results do |on|
+    on.success(result: [:value])
+    on.failure(:known)
+  end
+
+  def call!
+    Success(:other, result: { value: 1 })   # raises Micro::Case::Error::UnexpectedResultType
+    # Success(result: { wrong: 1 })         # raises Micro::Case::Error::MissingResultKeys
+    # Failure(:other)                       # raises Micro::Case::Error::UnexpectedResultType
+  end
+end
+```
+
+Notes:
+- Use cases without a `results` block keep their previous unrestricted behavior — the contract is opt-in.
+- Subclasses inherit the parent's contract.
+- Rescued exceptions in `Micro::Case::Safe` (which produce `Failure(result: exception)` automatically) bypass the contract.
 
 [⬆️ Back to Top](#table-of-contents-)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -27,7 +27,7 @@ Principais objetivos deste projeto:
 Versão    | Documentação
 --------- | -------------
 unreleased| https://github.com/serradura/u-case/blob/main/README.md
-5.4.0     | https://github.com/serradura/u-case/blob/v5.x/README.md
+5.5.0     | https://github.com/serradura/u-case/blob/v5.x/README.md
 4.5.1     | https://github.com/serradura/u-case/blob/v4.x/README.md
 
 ## Índice <!-- omit in toc -->
@@ -89,7 +89,7 @@ unreleased| https://github.com/serradura/u-case/blob/main/README.md
 | u-case           | branch | ruby     | activemodel    | u-attributes   |
 | ---------------- | ------ | -------- | -------------- | -------------- |
 | unreleased       | main   | >= 2.7   | >= 6.0         | >= 2.8, < 4.0  |
-| 5.4.0            | v5.x   | >= 2.7   | >= 6.0         | >= 2.8, < 4.0  |
+| 5.5.0            | v5.x   | >= 2.7   | >= 6.0         | >= 2.8, < 4.0  |
 | 5.1.0            | v5.x   | >= 2.7   | >= 6.0         | >= 2.7, < 4.0  |
 | 4.5.1            | v4.x   | >= 2.2.0 | >= 3.2, <= 8.1 | >= 2.7, < 3.0  |
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -40,6 +40,7 @@ unreleased| https://github.com/serradura/u-case/blob/main/README.md
     - [O que são os tipos de resultados?](#o-que-são-os-tipos-de-resultados)
     - [Como definir tipos customizados de resultados?](#como-definir-tipos-customizados-de-resultados)
     - [É possível definir um tipo sem definir os dados do resultado?](#é-possível-definir-um-tipo-sem-definir-os-dados-do-resultado)
+    - [Como declarar um contrato de resultados?](#como-declarar-um-contrato-de-resultados)
     - [Como utilizar os hooks dos resultados?](#como-utilizar-os-hooks-dos-resultados)
     - [Por que o hook sem um tipo definido expõe o próprio resultado?](#por-que-o-hook-sem-um-tipo-definido-expõe-o-próprio-resultado)
       - [Usando decomposição para acessar os dados e tipo do resultado](#usando-decomposição-para-acessar-os-dados-e-tipo-do-resultado)
@@ -330,6 +331,58 @@ result.use_case.attributes # {"a"=>2, "b"=>"2"}
 # Essa funcionalidade será muito útil para lidar com resultados de falha de um Flow
 # (este tópico será coberto em breve).
 ```
+
+[⬆️ Voltar para o índice](#índice-)
+
+#### Como declarar um contrato de resultados?
+
+Resposta: Utilize a macro `results do |on| ... end` para declarar quais tipos de resultado o caso de uso pode retornar e quais chaves cada um exige. Quando há um contrato declarado, chamadas a `Success(...)` / `Failure(...)` que usem um tipo não declarado levantam `Micro::Case::Error::UnexpectedResultType`, e chamadas que omitam uma chave obrigatória declarada levantam `Micro::Case::Error::MissingResultKeys`.
+
+```ruby
+class Divide < Micro::Case
+  attributes :a, :b
+
+  results do |on|
+    on.failure(:attributes_must_be_numbers)
+    on.failure(:division_by_zero)
+
+    on.success(result: [:division])
+  end
+
+  def call!
+    return Failure(:attributes_must_be_numbers) unless Kind.of?(Numeric, a, b)
+    return Failure(:division_by_zero) if b == 0
+
+    Success result: { division: a / b }
+  end
+end
+
+Divide.call(a: 10, b: 2).data # => { division: 5 }
+Divide.call(a: 10, b: 0).type # => :division_by_zero
+Divide.call(a: 'x', b: 2).type # => :attributes_must_be_numbers
+```
+
+Um tipo declarado em `on.success` / `on.failure` sem o argumento `result:` é aceito sem chaves obrigatórias (qualquer payload — inclusive o implícito `{ tipo => true }` de `Failure(:meu_tipo)` — é aceito). Quando `result: [:chave_1, :chave_2]` é informado, essas chaves precisam estar presentes no hash de resultado; chaves extras são permitidas.
+
+```ruby
+class Wrong < Micro::Case
+  results do |on|
+    on.success(result: [:value])
+    on.failure(:known)
+  end
+
+  def call!
+    Success(:other, result: { value: 1 })   # levanta Micro::Case::Error::UnexpectedResultType
+    # Success(result: { wrong: 1 })         # levanta Micro::Case::Error::MissingResultKeys
+    # Failure(:other)                       # levanta Micro::Case::Error::UnexpectedResultType
+  end
+end
+```
+
+Notas:
+- Casos de uso sem o bloco `results` mantêm o comportamento anterior sem restrições — o contrato é opt-in.
+- Subclasses herdam o contrato declarado na classe pai.
+- Exceções capturadas em `Micro::Case::Safe` (que geram `Failure(result: exception)` automaticamente) são exemptas do contrato.
 
 [⬆️ Voltar para o índice](#índice-)
 

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -69,6 +69,7 @@ module Micro
 
     def self.results(&block)
       raise ArgumentError, 'a block is required'.freeze unless block
+      raise ArgumentError, 'must be called on a Micro::Case subclass, not on Micro::Case itself'.freeze if self == ::Micro::Case
 
       @__results_contract = Result::Contract.define(&block)
     end
@@ -241,9 +242,10 @@ module Micro
       end
 
       def __failure_from_attributes_errors
-        Failure(
-          Config.instance.activemodel_validation_errors_failure,
-          result: { errors: attributes_errors }
+        __get_result(
+          false,
+          { errors: attributes_errors },
+          Config.instance.activemodel_validation_errors_failure
         )
       end
 

--- a/lib/micro/case.rb
+++ b/lib/micro/case.rb
@@ -11,6 +11,7 @@ module Micro
     require 'micro/case/utils'
     require 'micro/case/error'
     require 'micro/case/result'
+    require 'micro/case/result/contract'
     require 'micro/case/check'
     require 'micro/case/config'
     require 'micro/case/safe'
@@ -64,6 +65,19 @@ module Micro
 
     def self.flow(*args)
       @__flow_use_cases = Cases::Utils.map_use_cases(args)
+    end
+
+    def self.results(&block)
+      raise ArgumentError, 'a block is required'.freeze unless block
+
+      @__results_contract = Result::Contract.define(&block)
+    end
+
+    def self.__results_contract__
+      return @__results_contract if defined?(@__results_contract)
+
+      parent = superclass
+      parent.respond_to?(:__results_contract__) ? parent.__results_contract__ : nil
     end
 
     class << self
@@ -244,6 +258,8 @@ module Micro
       def Success(type = :ok, result: nil)
         value = result || type
 
+        ::Micro::Case.check.results_contract!(self.class, :success, type, value)
+
         __get_result(true, value, type)
       end
 
@@ -260,9 +276,10 @@ module Micro
 
         type = MapFailureType.call(value, type)
 
+        ::Micro::Case.check.results_contract!(self.class, :failure, type, value)
+
         __get_result(false, value, type)
       end
-
 
       def Check(type = nil, result: nil, on: Kind::Empty::HASH)
         result_key = type || :check

--- a/lib/micro/case/check.rb
+++ b/lib/micro/case/check.rb
@@ -59,6 +59,30 @@ module Micro
         def hash!(arg)
           Kind::Hash[arg]
         end
+
+        def results_contract!(use_case_class, kind, type, value)
+          contract = use_case_class.__results_contract__
+          return unless contract
+          return if value.is_a?(Exception)
+
+          if kind == :success
+            declared = contract.success_declared?(type)
+            declared_types = contract.successes.keys
+            required = contract.success_keys(type) if declared
+          else
+            declared = contract.failure_declared?(type)
+            declared_types = contract.failures.keys
+            required = contract.failure_keys(type) if declared
+          end
+
+          raise Error::UnexpectedResultType.new(use_case_class, kind, type, declared_types) unless declared
+          return if required.nil? || required.empty?
+
+          data = value.is_a?(Hash) ? value : { type => true }
+          missing = required - data.keys
+
+          raise Error::MissingResultKeys.new(use_case_class, kind, type, missing) unless missing.empty?
+        end
       end
 
       module Disabled
@@ -76,6 +100,7 @@ module Micro
         def flow_use_cases!(_use_cases); end
         def map_args!(_args); end
         def hash!(arg); arg; end
+        def results_contract!(_use_case_class, _kind, _type, _value); end
       end
     end
   end

--- a/lib/micro/case/check.rb
+++ b/lib/micro/case/check.rb
@@ -63,6 +63,7 @@ module Micro
         def results_contract!(use_case_class, kind, type, value)
           contract = use_case_class.__results_contract__
           return unless contract
+          return unless type.is_a?(Symbol)
           return if value.is_a?(Exception)
 
           if kind == :success
@@ -78,8 +79,15 @@ module Micro
           raise Error::UnexpectedResultType.new(use_case_class, kind, type, declared_types) unless declared
           return if required.nil? || required.empty?
 
-          data = value.is_a?(Hash) ? value : { type => true }
-          missing = required - data.keys
+          if value.is_a?(Hash)
+            data_keys = value.keys.map { |k| k.is_a?(String) ? k.to_sym : k }
+          elsif value.is_a?(Symbol)
+            data_keys = [type]
+          else
+            return
+          end
+
+          missing = required - data_keys
 
           raise Error::MissingResultKeys.new(use_case_class, kind, type, missing) unless missing.empty?
         end

--- a/lib/micro/case/error.rb
+++ b/lib/micro/case/error.rb
@@ -60,9 +60,32 @@ module Micro
         end
       end
 
+      class UnexpectedResultType < TypeError
+        def initialize(use_case_class, kind, type, declared_types)
+          declared_list = declared_types.map { |t| ":#{t}" }.join(', ')
+          declared_list = '(none)' if declared_list.empty?
+
+          super(
+            "#{use_case_class.name} declared a results contract — " \
+            "#{kind} type :#{type} is not declared. Declared #{kind} types: #{declared_list}."
+          )
+        end
+      end
+
+      class MissingResultKeys < ArgumentError
+        def initialize(use_case_class, kind, type, missing_keys)
+          missing_list = missing_keys.map { |k| ":#{k}" }.join(', ')
+
+          super(
+            "#{use_case_class.name} declared a results contract — " \
+            "#{kind} :#{type} is missing required result keys: #{missing_list}."
+          )
+        end
+      end
+
       def self.by_wrong_usage?(exception)
         case exception
-        when Kind::Error, ArgumentError, InvalidResult, UnexpectedResult then true
+        when Kind::Error, ArgumentError, InvalidResult, UnexpectedResult, UnexpectedResultType then true
         else false
         end
       end

--- a/lib/micro/case/result/contract.rb
+++ b/lib/micro/case/result/contract.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Micro
+  class Case
+    class Result
+      class Contract
+        attr_reader :successes, :failures
+
+        def self.define(&block)
+          contract = new
+          block.call(Definition.new(contract))
+          contract
+        end
+
+        def initialize
+          @successes = {}
+          @failures = {}
+        end
+
+        def add_success(type, keys)
+          @successes[type] = Array(keys).map(&:to_sym)
+        end
+
+        def add_failure(type, keys)
+          @failures[type] = Array(keys).map(&:to_sym)
+        end
+
+        def success_declared?(type)
+          @successes.key?(type)
+        end
+
+        def failure_declared?(type)
+          @failures.key?(type)
+        end
+
+        def success_keys(type)
+          @successes[type]
+        end
+
+        def failure_keys(type)
+          @failures[type]
+        end
+
+        class Definition
+          def initialize(contract)
+            @contract = contract
+          end
+
+          def success(type = :ok, result: nil)
+            @contract.add_success(Kind::Symbol[type], result)
+          end
+
+          def failure(type = :error, result: nil)
+            @contract.add_failure(Kind::Symbol[type], result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/micro/case/version.rb
+++ b/lib/micro/case/version.rb
@@ -2,6 +2,6 @@
 
 module Micro
   class Case
-    VERSION = '5.4.0'.freeze
+    VERSION = '5.5.0'.freeze
   end
 end

--- a/test/micro/case/disable_runtime_checks_test.rb
+++ b/test/micro/case/disable_runtime_checks_test.rb
@@ -145,4 +145,32 @@ class Micro::Case::DisableRuntimeChecksTest < Minitest::Test
     assert_predicate(result, :success?)
     assert_equal({ v: 6 }, result.value)
   end
+
+  class UseCaseWithBadContract < Micro::Case
+    results do |on|
+      on.success(result: [:value])
+      on.failure(:known)
+    end
+
+    def call!
+      Success(:undeclared, result: { value: 1 })
+    end
+  end
+
+  def test_disabling_skips_the_results_contract_check
+    Micro::Case.config do |config|
+      config.disable_runtime_checks = true
+    end
+
+    result = UseCaseWithBadContract.call
+
+    assert_predicate(result, :success?)
+    assert_equal(:undeclared, result.type)
+  end
+
+  def test_enabled_raises_for_the_results_contract_check
+    assert_raises(Micro::Case::Error::UnexpectedResultType) do
+      UseCaseWithBadContract.call
+    end
+  end
 end

--- a/test/micro/case/results_contract_test.rb
+++ b/test/micro/case/results_contract_test.rb
@@ -1,0 +1,194 @@
+require 'test_helper'
+
+class Micro::Case::ResultsContractTest < Minitest::Test
+  class Divide < Micro::Case
+    attributes :a, :b
+
+    results do |on|
+      on.failure(:attributes_must_be_numbers)
+      on.failure(:division_by_zero)
+
+      on.success(result: [:division])
+    end
+
+    def call!
+      return Failure(:attributes_must_be_numbers) unless Kind.of?(Numeric, a, b)
+      return Failure(:division_by_zero) if b == 0
+
+      Success result: { division: a / b }
+    end
+  end
+
+  def test_a_declared_success_with_required_keys_is_accepted
+    result = Divide.call(a: 10, b: 2)
+
+    assert_predicate(result, :success?)
+    assert_equal(:ok, result.type)
+    assert_equal(5, result[:division])
+  end
+
+  def test_a_declared_failure_type_without_keys_is_accepted
+    result1 = Divide.call(a: 'a', b: 2)
+    assert_predicate(result1, :failure?)
+    assert_equal(:attributes_must_be_numbers, result1.type)
+
+    result2 = Divide.call(a: 10, b: 0)
+    assert_predicate(result2, :failure?)
+    assert_equal(:division_by_zero, result2.type)
+  end
+
+  class Wrong < Micro::Case
+    attributes :a
+
+    results do |on|
+      on.failure(:known)
+      on.success(result: [:value])
+    end
+
+    def call!
+      case a
+      when :undeclared_success then Success(:other, result: { value: 1 })
+      when :undeclared_failure then Failure(:other)
+      when :missing_success_keys then Success(result: { wrong: 1 })
+      when :missing_failure_keys then Failure(:known)
+      else Success(result: { value: 1 })
+      end
+    end
+  end
+
+  def test_an_undeclared_success_type_raises
+    error = assert_raises(Micro::Case::Error::UnexpectedResultType) do
+      Wrong.call(a: :undeclared_success)
+    end
+
+    assert_match(/Wrong/, error.message)
+    assert_match(/success type :other/, error.message)
+    assert_match(/:ok/, error.message)
+  end
+
+  def test_an_undeclared_failure_type_raises
+    error = assert_raises(Micro::Case::Error::UnexpectedResultType) do
+      Wrong.call(a: :undeclared_failure)
+    end
+
+    assert_match(/Wrong/, error.message)
+    assert_match(/failure type :other/, error.message)
+    assert_match(/:known/, error.message)
+  end
+
+  def test_missing_required_success_keys_raises
+    error = assert_raises(Micro::Case::Error::MissingResultKeys) do
+      Wrong.call(a: :missing_success_keys)
+    end
+
+    assert_match(/Wrong/, error.message)
+    assert_match(/success.*:ok/, error.message)
+    assert_match(/:value/, error.message)
+  end
+
+  class WithKeyedFailure < Micro::Case
+    attributes :reason
+
+    results do |on|
+      on.failure(:invalid, result: [:reason])
+      on.success(result: [:value])
+    end
+
+    def call!
+      if reason
+        Failure(:invalid, result: { reason: reason })
+      else
+        Success(result: { value: 1 })
+      end
+    end
+  end
+
+  def test_required_failure_keys_are_validated
+    result = WithKeyedFailure.call(reason: 'bad')
+    assert_predicate(result, :failure?)
+    assert_equal('bad', result[:reason])
+  end
+
+  class MissingFailureKey < Micro::Case
+    results do |on|
+      on.failure(:invalid, result: [:reason])
+    end
+
+    def call!
+      Failure(:invalid)
+    end
+  end
+
+  def test_missing_required_failure_keys_raises
+    error = assert_raises(Micro::Case::Error::MissingResultKeys) do
+      MissingFailureKey.call
+    end
+
+    assert_match(/failure.*:invalid/, error.message)
+    assert_match(/:reason/, error.message)
+  end
+
+  class NoContract < Micro::Case
+    def call!
+      Success(:anything, result: { whatever: 1 })
+    end
+  end
+
+  def test_no_contract_means_no_validation
+    result = NoContract.call
+    assert_predicate(result, :success?)
+    assert_equal(:anything, result.type)
+  end
+
+  class InheritedContract < Divide
+  end
+
+  def test_subclasses_inherit_the_contract
+    result = InheritedContract.call(a: 10, b: 2)
+    assert_predicate(result, :success?)
+    assert_equal(5, result[:division])
+
+    assert_raises(Micro::Case::Error::UnexpectedResultType) do
+      Class.new(Divide) do
+        def call!
+          Success(:something_else, result: { division: 1 })
+        end
+      end.call(a: 1, b: 1)
+    end
+  end
+
+  class ExtraKeysAllowed < Micro::Case
+    results do |on|
+      on.success(result: [:value])
+    end
+
+    def call!
+      Success(result: { value: 1, extra: 2 })
+    end
+  end
+
+  def test_extra_keys_beyond_required_are_allowed
+    result = ExtraKeysAllowed.call
+    assert_predicate(result, :success?)
+    assert_equal(1, result[:value])
+    assert_equal(2, result[:extra])
+  end
+
+  class SafeWithContract < Micro::Case::Safe
+    results do |on|
+      on.success(result: [:value])
+      on.failure(:bad)
+    end
+
+    def call!
+      raise 'boom'
+    end
+  end
+
+  def test_safe_exception_failures_bypass_the_contract
+    result = SafeWithContract.call
+    assert_predicate(result, :failure?)
+    assert_equal(:exception, result.type)
+    assert_kind_of(RuntimeError, result[:exception])
+  end
+end

--- a/test/micro/case/results_contract_test.rb
+++ b/test/micro/case/results_contract_test.rb
@@ -191,4 +191,72 @@ class Micro::Case::ResultsContractTest < Minitest::Test
     assert_equal(:exception, result.type)
     assert_kind_of(RuntimeError, result[:exception])
   end
+
+  class AcceptAndContract < Micro::Case
+    attribute :name, accept: ->(v) { v.is_a?(String) }
+
+    results do |on|
+      on.success(result: [:greeting])
+      on.failure(:bad)
+    end
+
+    def call!
+      Success(result: { greeting: "hi #{name}" })
+    end
+  end
+
+  def test_attribute_validation_failure_bypasses_the_contract
+    result = AcceptAndContract.call(name: 123)
+    assert_predicate(result, :failure?)
+    assert_equal(Micro::Case::Config.instance.activemodel_validation_errors_failure, result.type)
+    refute_nil(result[:errors])
+  end
+
+  class StringKeyedResult < Micro::Case
+    results do |on|
+      on.success(result: [:value])
+    end
+
+    def call!
+      Success(result: { 'value' => 1 })
+    end
+  end
+
+  def test_string_keyed_result_satisfies_a_symbol_keyed_required
+    result = StringKeyedResult.call
+    assert_predicate(result, :success?)
+  end
+
+  class NonHashResultWithContract < Micro::Case
+    results do |on|
+      on.success(result: [:value])
+    end
+
+    def call!
+      Success(result: 'oops')
+    end
+  end
+
+  def test_non_hash_result_defers_to_invalid_result
+    assert_raises(Micro::Case::Error::InvalidResult) { NonHashResultWithContract.call }
+  end
+
+  def test_results_macro_is_rejected_on_micro_case_base_class
+    err = assert_raises(ArgumentError) { Micro::Case.results { |on| on.success(:ok) } }
+    assert_match(/Micro::Case itself/, err.message)
+  end
+
+  class NonSymbolType < Micro::Case
+    results do |on|
+      on.success(:ok, result: [:value])
+    end
+
+    def call!
+      Success('ok', result: { value: 1 })
+    end
+  end
+
+  def test_non_symbol_type_defers_to_invalid_result_type
+    assert_raises(Micro::Case::Error::InvalidResultType) { NonSymbolType.call }
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a class-level `results do |on| ... end` macro that declares the allowed `Success` / `Failure` types and the result keys each one requires.
- `Success(...)` / `Failure(...)` calls inside `call!` are validated against the contract: undeclared types raise `Micro::Case::Error::UnexpectedResultType`; missing required keys raise `Micro::Case::Error::MissingResultKeys`.
- Use cases without a `results` block keep their previous unrestricted behavior. Contracts are inherited by subclasses. The check routes through `Micro::Case::Check#results_contract!`, so it is also bypassed when `config.disable_runtime_checks = true`.

Closes #22.

## Example

```ruby
class Divide < Micro::Case
  attributes :a, :b

  results do |on|
    on.failure(:attributes_must_be_numbers)
    on.failure(:division_by_zero)

    on.success(result: [:division])
  end

  def call!
    return Failure(:attributes_must_be_numbers) unless Kind.of?(Numeric, a, b)
    return Failure(:division_by_zero) if b == 0

    Success result: { division: a / b }
  end
end
```

`Success(:other, ...)` or `Success(result: { wrong: 1 })` from inside `call!` would now raise.

## Carve-outs (from code review)

So contracts don't silently break neighbouring features:

- Framework-generated `__failure_from_attributes_errors` (the auto-failure produced when `accept:` / `reject:` or ActiveModel validation rejects an input) bypasses the contract — it goes directly to `__set__` rather than through `Failure(...)` — so combining `results` with attribute validation does **not** require declaring `:invalid_attributes`.
- Rescued exceptions in `Micro::Case::Safe` (which produce `Failure(result: exception)`) bypass the contract.
- Result hashes with `String` keys are matched against the contract's symbolised required keys — `Success(result: { 'value' => 1 })` satisfies `result: [:value]`, mirroring `Result`'s own tolerance for either key type.
- Non-`Hash` / non-`Symbol` `result:` arguments fall through to the existing `Micro::Case::Error::InvalidResult` ("must be a Hash") instead of being misreported as missing keys.
- Non-`Symbol` `type` arguments fall through to `Micro::Case::Error::InvalidResultType` instead of being misreported as undeclared.
- `Micro::Case.results` raises `ArgumentError` when called on the abstract base class itself, so a stray declaration cannot leak a contract to every subclass in the process.

## Documentation

- `README.md` and `README.pt-BR.md` — new **"How to declare a results contract?"** subsection (plus a TOC entry) so the macro is discoverable from the docs. Documentation + Compatibility tables bumped to 5.5.0 (dependency bounds unchanged).
- `CHANGELOG.md` — new `[5.5.0] - 2026-05-24` entry, listing the macro and every carve-out.
- `CLAUDE.md` — the "READMEs are part of every change" rule is tightened: new public API (macros, public methods, rescuable error classes, config options) now explicitly requires a README update in the same commit. The previous wording only covered changes to already-documented APIs, which is why the first commit shipped without README docs.

## Commits

1. `06e36bb` — Implementation + CHANGELOG entry + `test/micro/case/results_contract_test.rb` (11 cases) + `Check::Enabled#results_contract!` (with a no-op in `Check::Disabled`) + `disable_runtime_checks` coverage.
2. `52c64d4` — README.md + README.pt-BR.md docs.
3. `36a614d` — CLAUDE.md rule update.
4. `d7e5da8` — Code-review carve-outs (6 fixes, 5 new tests).
5. `d4d4798` — Bump to 5.5.0.

## Test plan

- [x] `bundle exec rake test` — 763 runs, 8113 assertions, 0 failures
- [x] `ENABLE_TRANSITIONS=false bundle exec rake test` — 502 runs, 7111 assertions, 0 failures
- [x] `test/micro/case/results_contract_test.rb` — 16 cases covering declared/undeclared types (success + failure), missing keys (success + failure), extra keys allowed, contract inheritance, no-contract pass-through, Safe exception bypass, accept/reject + contract co-existence, string-keyed payloads, non-Hash deferral, base-class guard, non-Symbol type deferral.
- [x] `test/micro/case/disable_runtime_checks_test.rb` — `disable_runtime_checks = true` skips the contract check; `false` raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)