### PR TITLE
Docs: add syntax notes section and encode no-breaking-changes Golden rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 Notes for AI assistants working in `u-case`.
 
+## Golden rule: no breaking API changes — ever
+
+`u-case`'s public API and runtime contracts are **frozen**. Every change must keep existing code working — the gem's role is to remain a stable, backward-compatible foundation for the projects that already depend on it (and for everything that transitively depends on them).
+
+Any "next major" rethink of the abstractions belongs in [`solid-process`](https://github.com/solid-process/solid-process) — a redesign that applies what we've learned since `u-case` was created — **not** in a future `u-case` 6.x.
+
+Major version bumps are reserved for dependency-floor changes (dropping a Ruby or Rails version from the supported matrix) per SemVer. They do **not** signal a behavior break.
+
+If a task as stated would require a breaking change to honor it, stop and surface that — propose a backward-compatible path, or flag that the request can't be satisfied without violating this rule. Don't ship the break.
+
 ## How to work in this repo
 
 ### 1. Think before coding

--- a/README.md
+++ b/README.md
@@ -142,6 +142,36 @@ See [Composing use cases](#composing-use-cases) and [Going further with `u-attri
 | 5.7.1      | https://github.com/serradura/u-case/blob/v5.x/README.md |
 | 4.5.2      | https://github.com/serradura/u-case/blob/v4.x/README.md |
 
+## A note on syntax <!-- omit in toc -->
+
+Examples in this README use two modern Ruby features. The gem itself supports Ruby `>= 2.7`, so if you're on an older runtime, here's how to read them back to the classic form.
+
+**[`it` block parameter](https://docs.ruby-lang.org/en/3.4/syntax/methods_rdoc.html#label-Numbered+parameters)** — Ruby 3.4+
+
+```ruby
+# Modern (Ruby >= 3.4) — what you'll see throughout this README
+attribute :title, accept: -> { it.is_a?(String) && !it.empty? }
+Slugify.call(title: 'Hello').on_success { puts it[:slug] }
+
+# Classic — equivalent on every supported Ruby
+attribute :title, accept: ->(value) { value.is_a?(String) && !value.empty? }
+Slugify.call(title: 'Hello').on_success { |data| puts data[:slug] }
+```
+
+**[Hash value omission](https://docs.ruby-lang.org/en/3.1/syntax/literals_rdoc.html#label-Hash+Literals)** — Ruby 3.1+
+
+When a hash key matches an in-scope local variable (or method) name, you can drop the value:
+
+```ruby
+slug = 'hello-world'
+
+# Modern (Ruby >= 3.1)
+Success(result: { slug: })
+
+# Classic — equivalent on every supported Ruby
+Success(result: { slug: slug })
+```
+
 ## Table of Contents <!-- omit in toc -->
 
 - [Compatibility](#compatibility)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -128,6 +128,36 @@ Veja [Compondo casos de uso](#compondo-casos-de-uso) e [Indo além com `u-attrib
 | 5.7.1      | https://github.com/serradura/u-case/blob/v5.x/README.pt-BR.md |
 | 4.5.2      | https://github.com/serradura/u-case/blob/v4.x/README.pt-BR.md |
 
+## Uma nota sobre sintaxe <!-- omit in toc -->
+
+Os exemplos neste README usam dois recursos modernos do Ruby. A gem em si suporta Ruby `>= 2.7`, então se você está em um runtime mais antigo, aqui está como interpretá-los na forma clássica.
+
+**[Parâmetro de bloco `it`](https://docs.ruby-lang.org/en/3.4/syntax/methods_rdoc.html#label-Numbered+parameters)** — Ruby 3.4+
+
+```ruby
+# Moderno (Ruby >= 3.4) — o que você verá ao longo deste README
+attribute :title, accept: -> { it.is_a?(String) && !it.empty? }
+Slugify.call(title: 'Olá').on_success { puts it[:slug] }
+
+# Clássico — equivalente em todo Ruby suportado
+attribute :title, accept: ->(value) { value.is_a?(String) && !value.empty? }
+Slugify.call(title: 'Olá').on_success { |data| puts data[:slug] }
+```
+
+**[Omissão de valor em hash](https://docs.ruby-lang.org/en/3.1/syntax/literals_rdoc.html#label-Hash+Literals)** — Ruby 3.1+
+
+Quando a chave de um hash coincide com o nome de uma variável local (ou método) no escopo, você pode omitir o valor:
+
+```ruby
+slug = 'ola-mundo'
+
+# Moderno (Ruby >= 3.1)
+Success(result: { slug: })
+
+# Clássico — equivalente em todo Ruby suportado
+Success(result: { slug: slug })
+```
+
 ## Índice <!-- omit in toc -->
 
 - [Compatibilidade](#compatibilidade)


### PR DESCRIPTION
## Summary

- **`README.md` / `README.pt-BR.md`** — add an "A note on syntax" section between the Documentation table and the Table of Contents, mirroring the one in `u-attributes`. Explains the two modern Ruby features used throughout the examples (`it` block parameter, Ruby 3.4+; hash value omission, Ruby 3.1+) and how to read them back to the classic form on supported older runtimes (Ruby `>= 2.7`).
- **`CLAUDE.md`** — encode the existing stability disclaimer as a top-level "Golden rule: no breaking API changes — ever". Captures that `u-case`'s public API is frozen, redesigns belong in [`solid-process`](https://github.com/solid-process/solid-process), and major bumps are reserved for dependency-floor changes per SemVer. Any task that would require a break must be surfaced rather than shipped.

No code, behavior, or dependency changes. No version bump.

## Test plan

- [x] Render `README.md` and confirm the new section sits between Documentation and Table of Contents, with both code blocks rendering correctly.
- [x] Render `README.pt-BR.md` and confirm the translation matches the English version in structure and tone.
- [x] Skim `CLAUDE.md` and confirm the Golden rule section is the first content block after the intro line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)