### PR TITLE
Add native ActiveSupport::Notifications hook for transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note:** This gem was originally published as `u-service` (versions 0.1.0 – 1.0.0) and renamed to `u-case` starting with `u-case 1.0.0` on 2019-09-15.
 
+## [Unreleased]
+### Added
+- Native `ActiveSupport::Notifications` instrumentation hook for transitions (closes #5). Opt-in via `Micro::Case::Config.instance.notifications = true`. When both transitions and the new flag are enabled, every `Micro::Case::Result#__set_transition` publishes a single `transition.micro_case` event whose payload exposes `:use_case_class`, `:attributes`, `:result_type`, `:result_kind` (`:success` | `:failure`), `:result_data`, and `:accessible_attributes`. The hook is additive — `Micro::Case::Result::Transitions::MapEverything`, `result.transitions`, and `Result.new(custom_mapper)` are unchanged.
+- `Micro::Case::Result::Notifications` module (`lib/micro/case/result/notifications.rb`) that detects `::ActiveSupport::Notifications` at require time via `Notifications::Available`. When unavailable, `publish` is redefined to a no-op so the transition hot path stays branch-free. `activesupport` is **not** a runtime dependency — host apps that have loaded it (Rails, or a manual `require 'active_support/notifications'`) get the integration for free; everyone else stays a no-op.
+- `Micro::Case::Config#notifications` / `#notifications=` accessors (default `false`, mirrors the existing `Kind::Boolean[value]` setter style). Setting `notifications = true` while `ActiveSupport::Notifications` is not loaded raises the new `Micro::Case::Error::NotificationsUnavailable` so misconfiguration fails loudly at boot rather than silently dropping events.
+- `Micro::Case::Config#notifications_event_name` / `#notifications_event_name=` accessors (default `'transition.micro_case'`) so apps can rename the published event to fit their own AS::Notifications namespace.
+- READMEs (EN + pt-BR) gain a top-level **Observability** section documenting the opt-in toggle, the payload schema, the Rack::MiniProfiler-step and `Rails.logger` subscriber recipes, and the synchronous-subscriber cost warning (AS::Notifications subscribers run on the same thread as the use case — keep them cheap).
+
 ## [5.7.1] - 2026-05-26
 ### Added
 - A `[!IMPORTANT]` GitHub alert at the top of both READMEs (EN + pt-BR) surfacing the **no-breaking-changes-to-the-API** policy (see [issue #131](https://github.com/serradura/u-case/issues/131#issuecomment-4531231882)) — the gem will remain a stable, backward-compatible foundation; redesigns belong in [`solid-process`](https://github.com/solid-process/solid-process). The alert also clarifies that major version bumps happen only when a Ruby or Rails version is dropped from the supported matrix (per SemVer dependency-floor semantics).
@@ -509,6 +517,7 @@ First release under the `u-case` name (renamed from `u-service`).
 - `Micro::Service::Result` with `Success`/`Failure` factories and helper methods for returning typed results from services.
 - Runtime dependency on `u-attributes` for service input declaration.
 
+[Unreleased]: https://github.com/serradura/u-case/compare/v5.7.1...HEAD
 [5.7.1]: https://github.com/serradura/u-case/compare/v5.7.0...v5.7.1
 [5.7.0]: https://github.com/serradura/u-case/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/serradura/u-case/compare/v5.5.0...v5.6.0

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ Success(result: { slug: slug })
       - [Internal-step flows under transactions](#internal-step-flows-under-transactions)
       - [Behavior notes](#behavior-notes)
 - [Configuration](#configuration)
+- [Observability](#observability)
+  - [Subscriber recipes](#subscriber-recipes)
+  - [Subscriber cost warning](#subscriber-cost-warning)
 - [Performance](#performance)
   - [Running the benchmarks](#running-the-benchmarks)
   - [Disabling runtime checks](#disabling-runtime-checks)
@@ -1454,6 +1457,83 @@ end
 ```
 
 All internal checks live in `Micro::Case::Check::Enabled` (the default). Toggling `disable_runtime_checks = true` swaps `Micro::Case.check` to `Micro::Case::Check::Disabled`, whose methods are no-ops — the validations themselves stop running on each call.
+
+[⬆️ Back to Top](#table-of-contents-)
+
+## Observability
+
+`u-case` can natively publish an `ActiveSupport::Notifications` event for every transition — the same chokepoint that already feeds `result.transitions`. Subscribers (Rails.logger, Rack::MiniProfiler, OpenTelemetry, StatsD, custom metrics) stay your responsibility — the gem only emits.
+
+`activesupport` is **not** a runtime dependency. The hook only activates when `ActiveSupport::Notifications` is already loaded in the host app (Rails apps get it automatically; non-Rails apps can `require 'active_support/notifications'`). Without it, the publish call is redefined to a no-op and the transition hot path stays branch-free.
+
+Opt in (off by default) in an initializer:
+
+```ruby
+Micro::Case.config do |config|
+  # Requires transitions to be enabled (the default) AND
+  # ActiveSupport::Notifications to be loaded. Raises
+  # Micro::Case::Error::NotificationsUnavailable otherwise.
+  config.notifications = true
+
+  # Override the default event name 'transition.micro_case' if you want
+  # it under a different AS::Notifications namespace.
+  # config.notifications_event_name = 'use_case.my_app'
+end
+```
+
+Every transition fires one `transition.micro_case` event with this payload:
+
+```ruby
+{
+  use_case_class:        Class,    # the use case that produced the transition
+  attributes:            Hash,     # symbolized use-case attributes (input)
+  result_type:           Symbol,   # result.type
+  result_kind:           Symbol,   # :success | :failure
+  result_data:           Hash,     # result.data (frozen)
+  accessible_attributes: Array     # result.accessible_attributes at this step
+}
+```
+
+`result.transitions.size` equals the number of events fired for that call — same chokepoint, just an extra publish.
+
+### Subscriber recipes
+
+**Rack::MiniProfiler step (development tracing):**
+
+```ruby
+# config/initializers/u_case.rb
+if Rails.env.development?
+  Micro::Case.config { |c| c.notifications = true }
+
+  ActiveSupport::Notifications.subscribe('transition.micro_case') do |*args|
+    event   = ActiveSupport::Notifications::Event.new(*args)
+    payload = event.payload
+    label   = "Micro::Case: #{payload[:use_case_class]} -> #{payload[:result_kind]}(:#{payload[:result_type]})"
+
+    Rack::MiniProfiler.step(label) { Rails.logger.debug(label) }
+  end
+end
+```
+
+**Structured `Rails.logger` trace:**
+
+```ruby
+ActiveSupport::Notifications.subscribe('transition.micro_case') do |*args|
+  event   = ActiveSupport::Notifications::Event.new(*args)
+  payload = event.payload
+
+  Rails.logger.info({
+    use_case:    payload[:use_case_class].name,
+    result:      "#{payload[:result_kind]}(:#{payload[:result_type]})",
+    data:        payload[:result_data],
+    duration_ms: event.duration.round(2)
+  }.to_json)
+end
+```
+
+### Subscriber cost warning
+
+> `ActiveSupport::Notifications` is synchronous. Anything a subscriber does runs on the same thread as the use case, between the mapper call and the caller. Keep subscribers cheap — log, increment a counter, or push to a queue. Heavy work (HTTP calls, DB writes, JSON encoding of large payloads) belongs in a background job, not in the subscriber.
 
 [⬆️ Back to Top](#table-of-contents-)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -206,6 +206,9 @@ Success(result: { slug: slug })
       - [Flows com steps internos sob transações](#flows-com-steps-internos-sob-transações)
       - [Observações de comportamento](#observações-de-comportamento)
 - [Configuração](#configuração)
+- [Observabilidade](#observabilidade)
+  - [Receitas de subscriber](#receitas-de-subscriber)
+  - [Aviso sobre o custo dos subscribers](#aviso-sobre-o-custo-dos-subscribers)
 - [Performance](#performance)
   - [Executando os benchmarks](#executando-os-benchmarks)
   - [Desabilitando os checks em runtime](#desabilitando-os-checks-em-runtime)
@@ -1441,6 +1444,83 @@ end
 ```
 
 Todos os checks internos vivem em `Micro::Case::Check::Enabled` (o padrão). Ativar `disable_runtime_checks = true` troca `Micro::Case.check` para `Micro::Case::Check::Disabled`, cujos métodos são no-ops — as validações em si param de rodar a cada chamada.
+
+[⬆️ Voltar ao topo](#índice-)
+
+## Observabilidade
+
+O `u-case` pode publicar nativamente um evento de `ActiveSupport::Notifications` para cada transition — o mesmo ponto único que já alimenta `result.transitions`. Os subscribers (Rails.logger, Rack::MiniProfiler, OpenTelemetry, StatsD, métricas customizadas) continuam sendo sua responsabilidade — a gem apenas emite.
+
+`activesupport` **não** é uma dependência de runtime. O hook só ativa quando `ActiveSupport::Notifications` já está carregado na aplicação host (apps Rails ganham isso automaticamente; apps não-Rails podem fazer `require 'active_support/notifications'`). Sem ele, a chamada de publish é redefinida como no-op e o hot path das transitions permanece sem branch.
+
+Habilite (desligado por padrão) em um initializer:
+
+```ruby
+Micro::Case.config do |config|
+  # Requer transitions habilitadas (o padrão) E
+  # ActiveSupport::Notifications carregado. Caso contrário, levanta
+  # Micro::Case::Error::NotificationsUnavailable.
+  config.notifications = true
+
+  # Sobrescreva o nome de evento padrão 'transition.micro_case' caso queira
+  # publicar em outro namespace de AS::Notifications.
+  # config.notifications_event_name = 'use_case.my_app'
+end
+```
+
+Cada transition dispara um evento `transition.micro_case` com este payload:
+
+```ruby
+{
+  use_case_class:        Class,    # o caso de uso que produziu a transition
+  attributes:            Hash,     # atributos do caso de uso (entrada, symbolizados)
+  result_type:           Symbol,   # result.type
+  result_kind:           Symbol,   # :success | :failure
+  result_data:           Hash,     # result.data (frozen)
+  accessible_attributes: Array     # result.accessible_attributes neste step
+}
+```
+
+`result.transitions.size` é igual ao número de eventos disparados na chamada — mesmo ponto único, só com um publish a mais.
+
+### Receitas de subscriber
+
+**Step do Rack::MiniProfiler (tracing em desenvolvimento):**
+
+```ruby
+# config/initializers/u_case.rb
+if Rails.env.development?
+  Micro::Case.config { |c| c.notifications = true }
+
+  ActiveSupport::Notifications.subscribe('transition.micro_case') do |*args|
+    event   = ActiveSupport::Notifications::Event.new(*args)
+    payload = event.payload
+    label   = "Micro::Case: #{payload[:use_case_class]} -> #{payload[:result_kind]}(:#{payload[:result_type]})"
+
+    Rack::MiniProfiler.step(label) { Rails.logger.debug(label) }
+  end
+end
+```
+
+**Trace estruturado no `Rails.logger`:**
+
+```ruby
+ActiveSupport::Notifications.subscribe('transition.micro_case') do |*args|
+  event   = ActiveSupport::Notifications::Event.new(*args)
+  payload = event.payload
+
+  Rails.logger.info({
+    use_case:    payload[:use_case_class].name,
+    result:      "#{payload[:result_kind]}(:#{payload[:result_type]})",
+    data:        payload[:result_data],
+    duration_ms: event.duration.round(2)
+  }.to_json)
+end
+```
+
+### Aviso sobre o custo dos subscribers
+
+> `ActiveSupport::Notifications` é síncrono. Qualquer coisa que um subscriber faça roda na mesma thread do caso de uso, entre a chamada do mapper e o chamador. Mantenha os subscribers baratos — logue, incremente um contador ou enfileire um job. Trabalho pesado (chamadas HTTP, escrita em DB, encoding de payloads grandes em JSON) pertence a um background job, não ao subscriber.
 
 [⬆️ Voltar ao topo](#índice-)
 

--- a/lib/micro/case/config.rb
+++ b/lib/micro/case/config.rb
@@ -53,6 +53,30 @@ module Micro
         @activemodel_validation_errors_failure = :invalid_attributes
       end
 
+      def notifications=(value)
+        enabled = Kind::Boolean[value]
+
+        raise ::Micro::Case::Error::NotificationsUnavailable if enabled && !::Micro::Case::Result::Notifications::Available
+
+        @notifications = enabled
+
+        ::Micro::Case::Result::Notifications.enabled = enabled
+      end
+
+      def notifications
+        return @notifications if defined?(@notifications)
+
+        @notifications = false
+      end
+
+      def notifications_event_name=(value)
+        ::Micro::Case::Result::Notifications.event_name = Kind::String[value]
+      end
+
+      def notifications_event_name
+        ::Micro::Case::Result::Notifications.event_name
+      end
+
       DEFAULT_TRANSACTION_CLASS_CALLBACK = -> { ::ActiveRecord::Base }.freeze
 
       def default_transaction_class=(callable)

--- a/lib/micro/case/error.rb
+++ b/lib/micro/case/error.rb
@@ -60,6 +60,16 @@ module Micro
         end
       end
 
+      class NotificationsUnavailable < StandardError
+        def initialize
+          super(
+            "Can't enable Micro::Case notifications: ActiveSupport::Notifications " \
+            "is not loaded. Add `require 'active_support/notifications'` (or load " \
+            "Rails / activesupport) before setting `config.notifications = true`."
+          )
+        end
+      end
+
       class UnexpectedResultType < TypeError
         def initialize(use_case_class, kind, type, declared_types)
           declared_list = declared_types.map { |t| ":#{t}" }.join(', ')

--- a/lib/micro/case/result.rb
+++ b/lib/micro/case/result.rb
@@ -7,6 +7,7 @@ module Micro
     class Result
       require 'micro/case/result/wrapper'
       require 'micro/case/result/transitions'
+      require 'micro/case/result/notifications'
 
       INVALID_INVOCATION_OF_THE_THEN_METHOD =
         Error::InvalidInvocationOfTheThenMethod.new("#{self.name}#")
@@ -295,6 +296,8 @@ module Micro
 
         def __set_transition(use_case_attributes)
           @__transitions << @__transitions_mapper.call(self, use_case_attributes)
+
+          Notifications.publish(self, use_case_attributes)
         end
 
       private_constant :FetchData, :INVALID_INVOCATION_OF_THE_THEN_METHOD

--- a/lib/micro/case/result/notifications.rb
+++ b/lib/micro/case/result/notifications.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Micro
+  class Case
+    class Result
+      module Notifications
+        Available = defined?(::ActiveSupport::Notifications) == 'constant'
+
+        DEFAULT_EVENT_NAME = 'transition.micro_case'.freeze
+
+        @enabled = false
+        @event_name = DEFAULT_EVENT_NAME
+
+        class << self
+          attr_accessor :enabled
+          attr_accessor :event_name
+        end
+
+        if Available
+          def self.publish(result, use_case_attributes)
+            return unless @enabled
+
+            ::ActiveSupport::Notifications.instrument(@event_name,
+              use_case_class:        result.use_case.class,
+              attributes:            use_case_attributes,
+              result_type:           result.type,
+              result_kind:           result.to_sym,
+              result_data:           result.data,
+              accessible_attributes: result.accessible_attributes
+            )
+          end
+        else
+          def self.publish(_result, _use_case_attributes); end
+        end
+      end
+    end
+  end
+end

--- a/test/micro/case/result/notifications_test.rb
+++ b/test/micro/case/result/notifications_test.rb
@@ -1,0 +1,238 @@
+require 'test_helper'
+
+class Micro::Case::Result::NotificationsTest < Minitest::Test
+  i_suck_and_my_tests_are_order_dependent!
+
+  EVENT_NAME = 'transition.micro_case'.freeze
+
+  def setup
+    skip 'ActiveSupport::Notifications not loaded in this bundle' unless Micro::Case::Result::Notifications::Available
+    skip 'transitions disabled in this bundle'                    unless Micro::Case::Result.transitions_enabled?
+
+    @events = []
+    @subscriber = ::ActiveSupport::Notifications.subscribe(EVENT_NAME) do |*args|
+      @events << ::ActiveSupport::Notifications::Event.new(*args)
+    end
+  end
+
+  def teardown
+    ::ActiveSupport::Notifications.unsubscribe(@subscriber) if @subscriber
+
+    Micro::Case.config do |config|
+      config.notifications = false
+    end
+
+    Micro::Case::Result::Notifications.event_name = Micro::Case::Result::Notifications::DEFAULT_EVENT_NAME
+  end
+
+  class SlugifySuccess < Micro::Case
+    attribute :title
+
+    def call!
+      Success(:slugified, result: { slug: title.downcase })
+    end
+  end
+
+  class SlugifyFailure < Micro::Case
+    attribute :title
+
+    def call!
+      Failure(:bad_title, result: { reason: 'blank' })
+    end
+  end
+
+  class Upcase < Micro::Case
+    attribute :slug
+
+    def call!
+      Success result: { slug: slug.upcase }
+    end
+  end
+
+  def test_the_default_value_is_false
+    assert_equal(false, Micro::Case::Config.instance.notifications)
+  end
+
+  def test_no_events_fire_by_default
+    SlugifySuccess.call(title: 'Hello')
+
+    assert_empty(@events)
+  end
+
+  def test_setting_to_a_non_boolean_raises
+    assert_raises_with_message(
+      Kind::Error,
+      '"yes" expected to be a kind of Boolean'
+    ) do
+      Micro::Case.config { |c| c.notifications = 'yes' }
+    end
+  end
+
+  def test_events_fire_when_enabled
+    Micro::Case.config { |c| c.notifications = true }
+
+    SlugifySuccess.call(title: 'Hello')
+
+    assert_equal(1, @events.size)
+  end
+
+  def test_payload_schema_keys
+    Micro::Case.config { |c| c.notifications = true }
+
+    SlugifySuccess.call(title: 'Hello')
+
+    expected_keys = [:use_case_class, :attributes, :result_type, :result_kind, :result_data, :accessible_attributes].sort
+
+    assert_equal(expected_keys, @events.first.payload.keys.sort)
+  end
+
+  def test_payload_values_for_success
+    Micro::Case.config { |c| c.notifications = true }
+
+    SlugifySuccess.call(title: 'Hello')
+
+    payload = @events.first.payload
+
+    assert_equal(SlugifySuccess,        payload[:use_case_class])
+    assert_equal({ title: 'Hello' },    payload[:attributes])
+    assert_equal(:slugified,            payload[:result_type])
+    assert_equal(:success,              payload[:result_kind])
+    assert_equal({ slug: 'hello' },     payload[:result_data])
+    assert_equal([:title],              payload[:accessible_attributes])
+  end
+
+  def test_payload_values_for_failure
+    Micro::Case.config { |c| c.notifications = true }
+
+    SlugifyFailure.call(title: 'Hello')
+
+    payload = @events.first.payload
+
+    assert_equal(SlugifyFailure,         payload[:use_case_class])
+    assert_equal(:bad_title,             payload[:result_type])
+    assert_equal(:failure,               payload[:result_kind])
+    assert_equal({ reason: 'blank' },    payload[:result_data])
+  end
+
+  def test_one_event_per_transition_in_a_flow
+    Micro::Case.config { |c| c.notifications = true }
+
+    Micro::Cases.flow([SlugifySuccess, Upcase]).call(title: 'Hello')
+
+    assert_equal(2, @events.size)
+
+    assert_equal(SlugifySuccess, @events[0].payload[:use_case_class])
+    assert_equal(Upcase,         @events[1].payload[:use_case_class])
+  end
+
+  def test_disabling_after_enabling_silences_events
+    Micro::Case.config { |c| c.notifications = true }
+    Micro::Case.config { |c| c.notifications = false }
+
+    SlugifySuccess.call(title: 'Hello')
+
+    assert_empty(@events)
+  end
+
+  def test_custom_event_name_is_respected
+    Micro::Case.config { |c| c.notifications = true }
+    Micro::Case.config { |c| c.notifications_event_name = 'use_case.custom' }
+
+    custom_events = []
+    subscriber = ::ActiveSupport::Notifications.subscribe('use_case.custom') do |*args|
+      custom_events << ::ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    begin
+      SlugifySuccess.call(title: 'Hello')
+
+      assert_equal(1, custom_events.size)
+      assert_empty(@events)
+    ensure
+      ::ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+  end
+
+  def test_custom_mapper_still_wins_for_transitions_and_event_still_fires
+    Micro::Case.config { |c| c.notifications = true }
+
+    custom_mapper = ->(result, attrs) { { custom: true, type: result.type } }
+
+    result = Micro::Case::Result.new(custom_mapper)
+    use_case = SlugifySuccess.__new__(result, { title: 'Hello' })
+    use_case.__call__
+
+    assert_equal([{ custom: true, type: :slugified }], result.transitions)
+
+    assert_equal(1, @events.size)
+    assert_equal(SlugifySuccess, @events.first.payload[:use_case_class])
+  end
+
+  def test_publish_is_a_noop_when_disabled_even_with_subscriber
+    assert_equal(false, Micro::Case::Result::Notifications.enabled)
+
+    Micro::Case::Result::Notifications.publish(Object.new, { irrelevant: true })
+
+    assert_empty(@events)
+  end
+end
+
+class Micro::Case::Result::NotificationsTransitionsDisabledTest < Minitest::Test
+  i_suck_and_my_tests_are_order_dependent!
+
+  EVENT_NAME = 'transition.micro_case'.freeze
+
+  def setup
+    skip 'ActiveSupport::Notifications not loaded in this bundle' unless Micro::Case::Result::Notifications::Available
+    skip 'transitions enabled in this bundle'                     if Micro::Case::Result.transitions_enabled?
+
+    @events = []
+    @subscriber = ::ActiveSupport::Notifications.subscribe(EVENT_NAME) do |*args|
+      @events << ::ActiveSupport::Notifications::Event.new(*args)
+    end
+  end
+
+  def teardown
+    ::ActiveSupport::Notifications.unsubscribe(@subscriber) if @subscriber
+
+    Micro::Case.config do |config|
+      config.notifications = false
+    end
+  end
+
+  class Noop < Micro::Case
+    def call!; Success(); end
+  end
+
+  def test_no_event_when_transitions_are_disabled
+    Micro::Case.config { |c| c.notifications = true }
+
+    Noop.call
+
+    assert_empty(@events)
+  end
+end
+
+class Micro::Case::Result::NotificationsAvailabilityTest < Minitest::Test
+  def test_setting_to_true_raises_when_active_support_notifications_is_unavailable
+    skip 'ActiveSupport::Notifications is loaded in this bundle' if Micro::Case::Result::Notifications::Available
+
+    assert_raises(Micro::Case::Error::NotificationsUnavailable) do
+      Micro::Case.config { |c| c.notifications = true }
+    end
+  end
+
+  def test_setting_to_false_does_not_raise_when_active_support_notifications_is_unavailable
+    skip 'ActiveSupport::Notifications is loaded in this bundle' if Micro::Case::Result::Notifications::Available
+
+    Micro::Case.config { |c| c.notifications = false }
+
+    assert_equal(false, Micro::Case::Config.instance.notifications)
+  end
+
+  def test_publish_is_safe_when_unavailable
+    skip 'ActiveSupport::Notifications is loaded in this bundle' if Micro::Case::Result::Notifications::Available
+
+    assert_nil(Micro::Case::Result::Notifications.publish(Object.new, {}))
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,18 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+# Loaded before `u-case` so Micro::Case::Result::Notifications::Available
+# is set to `true` whenever activesupport ships with the bundle (Rails
+# appraisals). On the default bundle this require fails silently and the
+# notifications hook stays a no-op — mirroring the host-app expectation
+# spelled out in lib/micro/case/result/notifications.rb.
+begin
+  require 'active_support'
+  require 'active_support/isolated_execution_state'
+  require 'active_support/notifications'
+rescue LoadError
+end
+
 require 'u-case'
 
 Micro::Case.config do |config|


### PR DESCRIPTION
## Summary

- New opt-in `Micro::Case::Result::Notifications` module that publishes one `transition.micro_case` `ActiveSupport::Notifications` event per transition, when both transitions and the new `config.notifications` flag are enabled. Payload exposes `:use_case_class`, `:attributes`, `:result_type`, `:result_kind` (`:success` | `:failure`), `:result_data`, and `:accessible_attributes` — plain Ruby values, safe for JSON-encoding subscribers (OTEL, structured logs, StatsD, Rack::MiniProfiler, etc.).
- `activesupport` stays out of runtime deps. The module probes `defined?(::ActiveSupport::Notifications)` at require time and redefines `publish` to a no-op when unavailable, so the transition hot path stays branch-free. Setting `notifications = true` while AS::Notifications is not loaded raises the new `Micro::Case::Error::NotificationsUnavailable` (fail-fast at boot rather than silently dropping events). Default is off — existing callers get no behavior change.
- Additive only per the no-breaking-changes policy: `Transitions::MapEverything`, `result.transitions`, and `Result.new(custom_mapper)` are unchanged. CHANGELOG entry under `[Unreleased]`; both READMEs (EN + pt-BR) gain a top-level **Observability** section with the Rack::MiniProfiler-step and `Rails.logger` subscriber recipes, plus the synchronous-subscriber cost warning.

## Test plan

- [x] `bundle exec rake test` — 811 runs, 0 failures (default bundle, AS::Notifications absent → unavailable-path tests run, happy-path tests skip)
- [x] `BUNDLE_GEMFILE=gemfiles/rails_8_1.gemfile bundle exec rake test` — 1058 runs, 0 failures (AS::Notifications loaded → full happy-path tests run, unavailable-path tests skip)
- [x] `ENABLE_TRANSITIONS=false bundle exec rake test` — 0 failures (transitions off → no events fire even with config flag on)
- [x] `ENABLE_TRANSITIONS=false BUNDLE_GEMFILE=gemfiles/rails_8_1.gemfile bundle exec rake test` — 0 failures
- [ ] Full `bundle exec rake matrix` across the Ruby × Rails × `ENABLE_TRANSITIONS` axes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)